### PR TITLE
Line detection fixes

### DIFF
--- a/deepdoctection/extern/doctrocr.py
+++ b/deepdoctection/extern/doctrocr.py
@@ -43,7 +43,7 @@ def doctr_predict_text_lines(np_img: ImageType, predictor: "DetectionPredictor")
     """
     raw_output = predictor([np_img])
     detection_results = [
-        DetectionResult(box=box[:4].tolist(), class_id=1, score=box[4], absolute_coords=False, class_name=names.C.LINE)
+        DetectionResult(box=box[:4].tolist(), class_id=1, score=box[4], absolute_coords=False, class_name=names.C.WORD)
         for box in raw_output[0]
     ]
     return detection_results

--- a/deepdoctection/pipe/doctectionpipe.py
+++ b/deepdoctection/pipe/doctectionpipe.py
@@ -76,7 +76,7 @@ class DoctectionPipe(Pipeline):  # pylint: disable=W0221
             elif not path_type:
                 raise ValueError("Pass only a path to a directory or to a pdf file")
 
-        file_type = kwargs.get("file_type", [".jpg", ".png"])
+        file_type = kwargs.get("file_type", [".jpg", ".png", ".tif"])
         max_datapoints = kwargs.get("max_datapoints")
 
         if isinstance(path, str):

--- a/deepdoctection/utils/fs.py
+++ b/deepdoctection/utils/fs.py
@@ -144,7 +144,7 @@ def load_image_from_file(path: str, type_id: str = "np") -> Optional[Union[str, 
     """
     image: Optional[Union[str, ImageType]] = None
 
-    assert is_file_extension(path, [".png", ".jpeg", ".jpg"]), f"image type not allowed: {path}"
+    assert is_file_extension(path, [".png", ".jpeg", ".jpg", ".tif"]), f"image type not allowed: {path}"
     assert type_id in ("np", "b64"), "type not allowed"
 
     try:


### PR DESCRIPTION
Two fixes of different nature:

- Fix category from doctr text line detector. Granularity is word and not line.

- Enable processing .tif files in doctection pipe