### PR TITLE
Add residual words and fix hf hub install requirement

### DIFF
--- a/deepdoctection/__init__.py
+++ b/deepdoctection/__init__.py
@@ -320,6 +320,7 @@ _IMPORT_STRUCTURE = {
         "Relationships",
         "Languages",
         "DatasetType",
+        "update_all_types_dict",
         "get_type",
         "sub_path",
         "get_package_path",

--- a/deepdoctection/pipe/doctectionpipe.py
+++ b/deepdoctection/pipe/doctectionpipe.py
@@ -70,7 +70,7 @@ class DoctectionPipe(Pipeline):
     def __init__(self, pipeline_component_list: List[Union[PipelineComponent]]):
         self.page_parser = PageParsingService(
             text_container=LayoutType.word,
-            text_block_names=[LayoutType.title, LayoutType.text, LayoutType.list, LayoutType.table],
+            top_level_text_block_names=[LayoutType.title, LayoutType.text, LayoutType.list, LayoutType.table],
         )
         assert all(
             isinstance(element, (PipelineComponent, PredictorPipelineComponent)) for element in pipeline_component_list

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _DEPS = [
     "apted==1.0.3",
     "catalogue==2.0.7",
     "distance==0.1.3",
-    "huggingface_hub>=0.4.0",
+    "huggingface_hub>=0.4.0,<0.11",
     "importlib-metadata>=4.11.2",
     "jsonlines==3.0.0",
     "lxml>=4.9.1",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _DEPS = [
     "apted==1.0.3",
     "catalogue==2.0.7",
     "distance==0.1.3",
-    "huggingface_hub>=0.4.0,<0.11",
+    "huggingface_hub>=0.4.0,<0.11.0",
     "importlib-metadata>=4.11.2",
     "jsonlines==3.0.0",
     "lxml>=4.9.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ from deepdoctection.utils.settings import (
     WordType,
     object_types_registry,
     update_all_types_dict,
+    update_black_list,
 )
 from deepdoctection.utils.systools import get_package_path
 
@@ -492,3 +493,5 @@ def pytest_sessionstart() -> None:
     """Pre configuration before testing starts"""
     object_types_registry.register("TestType", func=TestType)
     update_all_types_dict()
+    for item in TestType:
+        update_black_list(item.value)


### PR DESCRIPTION
This PR:

- adds a new attribute `residual_words` to `Page` so that words, that could not been assigned to layout blocks can be disclosed as well.
- Adds an upper version bound for hf hub.