### PR TITLE
Issue 95

### DIFF
--- a/deepdoctection/mapper/d2struct.py
+++ b/deepdoctection/mapper/d2struct.py
@@ -68,7 +68,11 @@ def image_to_d2_frcnn_training(
     annotations = []
 
     for ann in anns:
-        if ann.bounding_box is None:
+        if ann.image is not None:
+            box = ann.image.get_embedding(dp.image_id)
+        else:
+            box = ann.bounding_box
+        if box is None:
             raise ValueError("BoundingBox cannot be None")
         mapped_ann: Dict[str, Union[str, int, List[float]]] = {
             "bbox_mode": BoxMode.XYXY_ABS,

--- a/deepdoctection/mapper/d2struct.py
+++ b/deepdoctection/mapper/d2struct.py
@@ -76,7 +76,7 @@ def image_to_d2_frcnn_training(
             raise ValueError("BoundingBox cannot be None")
         mapped_ann: Dict[str, Union[str, int, List[float]]] = {
             "bbox_mode": BoxMode.XYXY_ABS,
-            "bbox": ann.bounding_box.to_list(mode="xyxy"),
+            "bbox": box.to_list(mode="xyxy"),
             "category_id": int(ann.category_id) - 1,
         }
         annotations.append(mapped_ann)

--- a/deepdoctection/mapper/tpstruct.py
+++ b/deepdoctection/mapper/tpstruct.py
@@ -56,8 +56,12 @@ def image_to_tp_frcnn_training(
         return None
 
     for ann in anns:
-        if ann.bounding_box is None:
-            raise ValueError("ann.bounding_box cannot be None")
+        if ann.image is not None:
+            box = ann.image.get_embedding(dp.image_id)
+        else:
+            box = ann.bounding_box
+        if box is None:
+            raise ValueError("BoundingBox cannot be None")
         all_boxes.append(ann.bounding_box.to_list(mode="xyxy"))
         all_categories.append(ann.category_id)
 

--- a/deepdoctection/mapper/tpstruct.py
+++ b/deepdoctection/mapper/tpstruct.py
@@ -62,7 +62,7 @@ def image_to_tp_frcnn_training(
             box = ann.bounding_box
         if box is None:
             raise ValueError("BoundingBox cannot be None")
-        all_boxes.append(ann.bounding_box.to_list(mode="xyxy"))
+        all_boxes.append(box.to_list(mode="xyxy"))
         all_categories.append(ann.category_id)
 
         if add_mask:


### PR DESCRIPTION
This PR fixes issue #95:

It adds an additional bounding box selection logic for `ImageAnnotation`. Follow the general convention one should first log for
a bounding box in its `image` attribute and only use the `bounding_box` attribute as fall-back. 