### PR TITLE
Adding state_id for Annotation and Image

### DIFF
--- a/deepdoctection/mapper/laylmstruct.py
+++ b/deepdoctection/mapper/laylmstruct.py
@@ -672,8 +672,16 @@ def image_to_layoutlm_features(
     :return: A dict of layoutlm features
     """
     raw_features = image_to_raw_layoutlm_features(
-        None, input_width, input_height, image_width, image_height, color_mode, pixel_mean, pixel_std, True,
-        segment_positions
+        None,
+        input_width,
+        input_height,
+        image_width,
+        image_height,
+        color_mode,
+        pixel_mean,
+        pixel_std,
+        True,
+        segment_positions,
     )(dp)
     if raw_features is None:
         return None

--- a/deepdoctection/utils/concurrency.py
+++ b/deepdoctection/utils/concurrency.py
@@ -112,7 +112,9 @@ def enable_death_signal(_warn: bool = True) -> None:
         # is SIGHUP a good choice?
         prctl.set_pdeathsig(signal.SIGHUP)
 
+
 # taken from https://github.com/tensorpack/dataflow/blob/master/dataflow/utils/concurrency.py
+
 
 @no_type_check
 def start_proc_mask_signal(proc):

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ docs_deps = deps_list(
     "jinja2",
     "mkdocs-material",
     "mkdocstrings-python",
-    "griffe"
+    "griffe",
 )
 
 

--- a/tests/datapoint/test_annotation.py
+++ b/tests/datapoint/test_annotation.py
@@ -141,4 +141,4 @@ class TestCategoryAnnotation:
         cat.dump_sub_category(get_type("bak"), sub_cat_1)
 
         # Assert
-        assert cat.state_id == "58d80ed6-8023-3e74-a02b-bc07cf2aa52c"
+        assert cat.state_id == "8301eef5-bd4a-3c10-9dad-7cae94dd150b"

--- a/tests/datapoint/test_annotation.py
+++ b/tests/datapoint/test_annotation.py
@@ -122,3 +122,23 @@ class TestCategoryAnnotation:
         # Assert
         with pytest.raises(Exception):
             cat.get_sub_category(get_type("bak"))
+
+    @staticmethod
+    @mark.basic
+    def test_state_id() -> None:
+        """
+        state_id is correctly determined based by given state attributes
+        """
+
+        # Arrange
+        cat = CategoryAnnotation(
+            category_name="FOO", category_id="1", external_id="c822f8c3-1148-30c4-90eb-cb4896b1e222"
+        )
+        sub_cat_1 = CategoryAnnotation(
+            category_name="FOOBAK", category_id="2", external_id="c822f8c3-1148-30c4-90eb-cb4896b1ebe5"
+        )
+        # Act
+        cat.dump_sub_category(get_type("bak"), sub_cat_1)
+
+        # Assert
+        assert cat.state_id == "58d80ed6-8023-3e74-a02b-bc07cf2aa52c"

--- a/tests/datapoint/test_image.py
+++ b/tests/datapoint/test_image.py
@@ -294,3 +294,38 @@ class TestImage:
         df = MapData(df, lambda dp: Image.from_dict(**dp))
         image_list = collect_datapoint_from_dataflow(df)
         assert len(image_list) == 1
+
+    @staticmethod
+    @mark.basic
+    def test_state_id_changes_when_annotations_added(image: WhiteImage) -> None:
+        """
+        state_id changes when annotations are added
+        """
+
+        # Arrange
+        test_image = Image(location=image.loc, file_name=image.file_name)
+        cat_1 = ImageAnnotation(
+            category_name="FOO",
+            category_id="1",
+            bounding_box=BoundingBox(ulx=1.0, uly=1.0, width=1.0, height=2.0, absolute_coords=True),
+        )
+        cat_2 = ImageAnnotation(
+            category_name="BAK",
+            category_id="2",
+            bounding_box=BoundingBox(ulx=2.0, uly=2.0, width=2.0, height=2.0, absolute_coords=True),
+        )
+        cat_3 = ImageAnnotation(
+            category_name="BAK",
+            category_id="1",
+            bounding_box=BoundingBox(ulx=1.5, uly=2.4, width=3.0, height=9.0, absolute_coords=True),
+        )
+
+        test_image.dump(cat_1)
+        test_image.dump(cat_2)
+
+        # Assert
+        assert test_image.state_id == "ec2d4ac5-a4dc-351f-b869-3ec6334d9906"
+
+        # Act
+        test_image.dump(cat_3)
+        assert test_image.state_id == "ceb9021b-c96d-36e1-9cd5-465b48cae58b"


### PR DESCRIPTION
`annotation_id` and `image_id` are being used to identify an annotation. When comparing annotations and images over time, they can change when sub categories, relationships have been added etc.
 
The `state_id` allows to easily determine equality of one Annotation or Image over time. It collects all hashes of lower hierachy objects and generates a new uuid.