### PR TITLE
Issue #124 - quick fix downgrade transformers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ _DEPS = [
     "tensorpack",
     # PyTorch related dependencies
     "timm",
-    "transformers",
+    "transformers<=4.24",
     "detectron2 @ git+https://github.com/facebookresearch/detectron2.git",
     # other third party related dependencies (services or DL libraries). Must be installed by users
     "jdeskew",


### PR DESCRIPTION
Allow to install `transformers<=4.24` 