### PR TITLE
Enhancing text ordering and table segmentation process

### DIFF
--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -665,7 +665,10 @@ class Page(Image):
         elif path is None:
             path = Path(self.image_orig.location)
         suffix = path.suffix
-        path_json = path.as_posix().replace(suffix, ".json")
+        if suffix:
+            path_json = path.as_posix().replace(suffix, ".json")
+        else:
+            path_json = path.as_posix() + ".json"
         if highest_hierarchy_only:
             self.image_orig.remove_image_from_lower_hierachy()
         export_dict = self.image_orig.as_dict()

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -581,7 +581,7 @@ class Page(Image):
                 category_names_list.append(LayoutType.table)
                 if show_cells:
                     for cell in table.cells:
-                        if cell.category_name != LayoutType.cell:
+                        if cell.category_name == LayoutType.cell:
                             cells_found = True
                             box_stack.append(cell.bbox)
                             category_names_list.append(None)
@@ -597,7 +597,7 @@ class Page(Image):
 
         if show_cells and not cells_found:
             for ann in self.annotations:
-                if isinstance(ann, Cell):
+                if isinstance(ann, Cell) and ann.active:
                     box_stack.append(ann.bbox)
                     category_names_list.append(None)
 

--- a/deepdoctection/pipe/refine.py
+++ b/deepdoctection/pipe/refine.py
@@ -459,6 +459,15 @@ class TableSegmentationRefinementService(PipelineComponent):
             max_row_span = max([int(cell.get_sub_category(CellType.row_span).category_id) for cell in cells])
             max_col_span = max([int(cell.get_sub_category(CellType.column_span).category_id) for cell in cells])
             # TODO: the summaries should be sub categories of the underlying ann
+            if TableType.number_of_rows in table.sub_categories:
+                table.remove_sub_category(TableType.number_of_rows)
+            if TableType.number_of_columns in table.sub_categories:
+                table.remove_sub_category(TableType.number_of_columns)
+            if TableType.max_row_span in table.sub_categories:
+                table.remove_sub_category(TableType.max_row_span)
+            if TableType.max_col_span in table.sub_categories:
+                table.remove_sub_category(TableType.max_col_span)
+
             self.dp_manager.set_summary_annotation(
                 TableType.number_of_rows, TableType.number_of_rows, number_of_rows, annotation_id=table.annotation_id
             )

--- a/deepdoctection/pipe/segment.py
+++ b/deepdoctection/pipe/segment.py
@@ -727,6 +727,29 @@ class TableSegmentationService(PipelineComponent):
                     CellType.column_span, segment_result.cs, CellType.column_span, segment_result.annotation_id
                 )
 
+            cells = table.image.get_annotation(category_names=self._cell_names)
+            number_of_rows = max([int(cell.get_sub_category(CellType.row_number).category_id) for cell in cells])
+            number_of_cols = max([int(cell.get_sub_category(CellType.column_number).category_id) for cell in cells])
+            max_row_span = max([int(cell.get_sub_category(CellType.row_span).category_id) for cell in cells])
+            max_col_span = max([int(cell.get_sub_category(CellType.column_span).category_id) for cell in cells])
+            # TODO: the summaries should be sub categories of the underlying ann
+            self.dp_manager.set_summary_annotation(
+                TableType.number_of_rows, TableType.number_of_rows, number_of_rows,
+                annotation_id=table.annotation_id
+            )
+            self.dp_manager.set_summary_annotation(
+                TableType.number_of_columns,
+                TableType.number_of_columns,
+                number_of_cols,
+                annotation_id=table.annotation_id,
+            )
+            self.dp_manager.set_summary_annotation(
+                TableType.max_row_span, TableType.max_row_span, max_row_span, annotation_id=table.annotation_id
+            )
+            self.dp_manager.set_summary_annotation(
+                TableType.max_col_span, TableType.max_col_span, max_col_span, annotation_id=table.annotation_id
+            )
+
     def clone(self) -> PipelineComponent:
         return self.__class__(
             self.segment_rule,

--- a/deepdoctection/pipe/segment.py
+++ b/deepdoctection/pipe/segment.py
@@ -727,28 +727,29 @@ class TableSegmentationService(PipelineComponent):
                     CellType.column_span, segment_result.cs, CellType.column_span, segment_result.annotation_id
                 )
 
-            cells = table.image.get_annotation(category_names=self._cell_names)
-            number_of_rows = max([int(cell.get_sub_category(CellType.row_number).category_id) for cell in cells])
-            number_of_cols = max([int(cell.get_sub_category(CellType.column_number).category_id) for cell in cells])
-            max_row_span = max([int(cell.get_sub_category(CellType.row_span).category_id) for cell in cells])
-            max_col_span = max([int(cell.get_sub_category(CellType.column_span).category_id) for cell in cells])
-            # TODO: the summaries should be sub categories of the underlying ann
-            self.dp_manager.set_summary_annotation(
+            if table.image:
+                cells = table.image.get_annotation(category_names=self._cell_names)
+                number_of_rows = max([int(cell.get_sub_category(CellType.row_number).category_id) for cell in cells])
+                number_of_cols = max([int(cell.get_sub_category(CellType.column_number).category_id) for cell in cells])
+                max_row_span = max([int(cell.get_sub_category(CellType.row_span).category_id) for cell in cells])
+                max_col_span = max([int(cell.get_sub_category(CellType.column_span).category_id) for cell in cells])
+                # TODO: the summaries should be sub categories of the underlying ann
+                self.dp_manager.set_summary_annotation(
                 TableType.number_of_rows, TableType.number_of_rows, number_of_rows,
                 annotation_id=table.annotation_id
-            )
-            self.dp_manager.set_summary_annotation(
+                )
+                self.dp_manager.set_summary_annotation(
                 TableType.number_of_columns,
                 TableType.number_of_columns,
                 number_of_cols,
                 annotation_id=table.annotation_id,
-            )
-            self.dp_manager.set_summary_annotation(
+                )
+                self.dp_manager.set_summary_annotation(
                 TableType.max_row_span, TableType.max_row_span, max_row_span, annotation_id=table.annotation_id
-            )
-            self.dp_manager.set_summary_annotation(
+                )
+                self.dp_manager.set_summary_annotation(
                 TableType.max_col_span, TableType.max_col_span, max_col_span, annotation_id=table.annotation_id
-            )
+                )
 
     def clone(self) -> PipelineComponent:
         return self.__class__(

--- a/deepdoctection/pipe/segment.py
+++ b/deepdoctection/pipe/segment.py
@@ -735,20 +735,22 @@ class TableSegmentationService(PipelineComponent):
                 max_col_span = max([int(cell.get_sub_category(CellType.column_span).category_id) for cell in cells])
                 # TODO: the summaries should be sub categories of the underlying ann
                 self.dp_manager.set_summary_annotation(
-                TableType.number_of_rows, TableType.number_of_rows, number_of_rows,
-                annotation_id=table.annotation_id
+                    TableType.number_of_rows,
+                    TableType.number_of_rows,
+                    number_of_rows,
+                    annotation_id=table.annotation_id,
                 )
                 self.dp_manager.set_summary_annotation(
-                TableType.number_of_columns,
-                TableType.number_of_columns,
-                number_of_cols,
-                annotation_id=table.annotation_id,
+                    TableType.number_of_columns,
+                    TableType.number_of_columns,
+                    number_of_cols,
+                    annotation_id=table.annotation_id,
                 )
                 self.dp_manager.set_summary_annotation(
-                TableType.max_row_span, TableType.max_row_span, max_row_span, annotation_id=table.annotation_id
+                    TableType.max_row_span, TableType.max_row_span, max_row_span, annotation_id=table.annotation_id
                 )
                 self.dp_manager.set_summary_annotation(
-                TableType.max_col_span, TableType.max_col_span, max_col_span, annotation_id=table.annotation_id
+                    TableType.max_col_span, TableType.max_col_span, max_col_span, annotation_id=table.annotation_id
                 )
 
     def clone(self) -> PipelineComponent:


### PR DESCRIPTION
This PR fixes some minor issues related to table segmentation, text ordering and visualisation:

- Deactivated cells will not be shown anymore in `page.viz`.
- Earlier, a summary for number of rows, columns for tables would have been added only if the refinement process had been integrated into a project. A summary has therefore been added into the segmentation service as well.
-  Text ordering has been slightly enhanced and a bug has been fixed. The enhancement takes into consideration that one had side you want to have tables integrated into the reading order enumeration. On the other side you need to handle them different to text/title/list blocks especially if they interrupt the layout pattern and span over multiple columns. 
- `TextOrderService` has been made more customizable.