### PR TITLE
Allow loading custom DocTr models in `DoctrTextlineDetector` and `DoctrTextRecognizer`

### DIFF
--- a/deepdoctection/dataflow/parallel_map.py
+++ b/deepdoctection/dataflow/parallel_map.py
@@ -358,7 +358,7 @@ class MultiProcessMapData(_ParallelMapData, _MultiProcessZMQDataFlow):
         @no_type_check
         def run(self):
             enable_death_signal(_warn=self.identity == b"0")
-            ctx = zmq.Context()  # pylint: disable=E0110
+            ctx = zmq.Context()
             socket = ctx.socket(zmq.REP)
             socket.setsockopt(zmq.IDENTITY, self.identity)
             socket.set_hwm(self.hwm)
@@ -410,7 +410,7 @@ class MultiProcessMapData(_ParallelMapData, _MultiProcessZMQDataFlow):
         _ParallelMapData.reset_state(self)
         self._guard = DataFlowReentrantGuard()
 
-        self.context = zmq.Context()  # type: ignore  # pylint: disable=E0110
+        self.context = zmq.Context()  # type: ignore
         self.socket = self.context.socket(zmq.DEALER)  # type: ignore
         self.socket.set_hwm(self._buffer_size * 2)  # type: ignore
         pipename = _get_pipe_name("dataflow-map")

--- a/deepdoctection/extern/doctrocr.py
+++ b/deepdoctection/extern/doctrocr.py
@@ -48,15 +48,13 @@ if pytorch_available():
     import torch
 
 if tf_available():
-    import tensorflow as tf  # type: ignore
+    import tensorflow as tf  # type: ignore  # pylint: disable=E0401
 
 
 def _set_device_str(device: Optional[str] = None) -> str:
     if device is not None:
         if tf_available():
             device = "/" + device.replace("cuda", "gpu") + ":0"
-        else:
-            device = device
     elif pytorch_available():
         device = set_torch_auto_device()
     else:
@@ -76,8 +74,8 @@ def _load_model(path_weights: str, doctr_predictor: Any, device: str) -> None:
         params_path = Path(path_weights).parent
         is_zip_path = path_weights.endswith(".zip")
         if is_zip_path:
-            with ZipFile(path_weights, "r") as f:
-                f.extractall(path=params_path)
+            with ZipFile(path_weights, "r") as file:
+                file.extractall(path=params_path)
                 doctr_predictor.model.load_weights(params_path / "weights")
         else:
             doctr_predictor.model.load_weights(path_weights)
@@ -183,7 +181,7 @@ class DoctrTextlineDetector(ObjectDetector):
             arch=self.architecture, pretrained=False, pretrained_backbone=False
         )  # we will be loading the model
         # later because there is no easy way in doctr to load a model by giving only a path to its weights
-        self.categories = categories # type: ignore
+        self.categories = categories  # type: ignore
         self.device_input = device
         self.device = _set_device_str(device)
         self.load_model()
@@ -213,6 +211,7 @@ class DoctrTextlineDetector(ObjectDetector):
         return [LayoutType.word]
 
     def load_model(self) -> None:
+        """Loading model weights"""
         _load_model(self.path_weights, self.doctr_predictor, self.device)
 
 
@@ -286,4 +285,5 @@ class DoctrTextRecognizer(TextRecognizer):
         return self.__class__(self.architecture, self.path_weights, self.device_input)
 
     def load_model(self) -> None:
+        """Loading model weights"""
         _load_model(self.path_weights, self.doctr_predictor, self.device)

--- a/deepdoctection/extern/model.py
+++ b/deepdoctection/extern/model.py
@@ -439,19 +439,19 @@ class ModelCatalog:
         "doctr/db_resnet50/pt/db_resnet50-ac60cadc.pt": ModelProfile(
             name="doctr/db_resnet50/pt/db_resnet50-ac60cadc.pt",
             description="Doctr implementation of DBNet from “Real-time Scene Text Detection with Differentiable "
-                        "Binarization”. For more information please check "
-                        "https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Pytorch artefact.",
+            "Binarization”. For more information please check "
+            "https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Pytorch artefact.",
             size=[101971449],
             urls=["https://doctr-static.mindee.com/models?id=v0.3.1/db_resnet50-ac60cadc.pt&src=0"],
-            categories= {"1": LayoutType.word},
+            categories={"1": LayoutType.word},
             dl_library="PT",
             model_wrapper="DoctrTextlineDetector",
         ),
         "doctr/db_resnet50/tf/db_resnet50-adcafc63.zip": ModelProfile(
             name="doctr/db_resnet50/tf/db_resnet50-adcafc63.zip",
             description="Doctr implementation of DBNet from “Real-time Scene Text Detection with Differentiable "
-                        "Binarization”. For more information please check "
-                        "https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Tensorflow artefact.",
+            "Binarization”. For more information please check "
+            "https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Tensorflow artefact.",
             size=[94178964],
             urls=["https://doctr-static.mindee.com/models?id=v0.2.0/db_resnet50-adcafc63.zip&src=0"],
             categories={"1": LayoutType.word},
@@ -461,12 +461,23 @@ class ModelCatalog:
         "doctr/crnn_vgg16_bn/pt/crnn_vgg16_bn-9762b0b0.pt": ModelProfile(
             name="doctr/crnn_vgg16_bn/pt/crnn_vgg16_bn-9762b0b0.pt",
             description="Doctr implementation of CRNN from “An End-to-End Trainable Neural Network for Image-based "
-                        "Sequence Recognition and Its Application to Scene Text Recognition”. For more information "
-                        "please check https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Pytorch "
-                        "artefact.",
+            "Sequence Recognition and Its Application to Scene Text Recognition”. For more information "
+            "please check https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Pytorch "
+            "artefact.",
             size=[63286381],
             urls=["https://doctr-static.mindee.com/models?id=v0.3.1/crnn_vgg16_bn-9762b0b0.pt&src=0"],
             dl_library="PT",
+            model_wrapper="DoctrTextRecognizer",
+        ),
+        "doctr/crnn_vgg16_bn/tf/crnn_vgg16_bn-76b7f2c6.zip": ModelProfile(
+            name="doctr/crnn_vgg16_bn/tf/crnn_vgg16_bn-76b7f2c6.zip",
+            description="Doctr implementation of CRNN from “An End-to-End Trainable Neural Network for Image-based "
+            "Sequence Recognition and Its Application to Scene Text Recognition”. For more information "
+            "please check https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Tensorflow "
+            "artefact.",
+            size=[58758994],
+            urls=["https://doctr-static.mindee.com/models?id=v0.3.0/crnn_vgg16_bn-76b7f2c6.zip&src=0"],
+            dl_library="TF",
             model_wrapper="DoctrTextRecognizer",
         ),
         "fasttext/lid.176.bin": ModelProfile(

--- a/deepdoctection/extern/model.py
+++ b/deepdoctection/extern/model.py
@@ -54,6 +54,7 @@ class ModelProfile:
     hf_config_file: Optional[List[str]] = field(default=None)
     urls: Optional[List[str]] = field(default=None)
     categories: Optional[Dict[str, ObjectTypes]] = field(default=None)
+    dl_library: Optional[str] = field(default=None)
     model_wrapper: Optional[str] = field(default=None)
 
     def as_dict(self) -> Dict[str, Any]:
@@ -104,6 +105,7 @@ class ModelCatalog:
                 "4": LayoutType.table,
                 "5": LayoutType.figure,
             },
+            dl_library="TF",
             model_wrapper="TPFrcnnDetector",
         ),
         "cell/model-1800000_inf_only.data-00000-of-00001": ModelProfile(
@@ -116,6 +118,7 @@ class ModelCatalog:
             hf_model_name="model-1800000_inf_only",
             hf_config_file=["conf_frcnn_cell.yaml"],
             categories={"1": LayoutType.cell},
+            dl_library="TF",
             model_wrapper="TPFrcnnDetector",
         ),
         "item/model-1620000_inf_only.data-00000-of-00001": ModelProfile(
@@ -128,6 +131,7 @@ class ModelCatalog:
             hf_model_name="model-1620000_inf_only",
             hf_config_file=["conf_frcnn_rows.yaml"],
             categories={"1": LayoutType.row, "2": LayoutType.column},
+            dl_library="TF",
             model_wrapper="TPFrcnnDetector",
         ),
         "item/model-1620000.data-00000-of-00001": ModelProfile(
@@ -140,6 +144,7 @@ class ModelCatalog:
             hf_model_name="model-1620000",
             hf_config_file=["conf_frcnn_rows.yaml"],
             categories={"1": LayoutType.row, "2": LayoutType.column},
+            dl_library="TF",
             model_wrapper="TPFrcnnDetector",
         ),
         "layout/model-800000.data-00000-of-00001": ModelProfile(
@@ -151,6 +156,7 @@ class ModelCatalog:
             hf_repo_id="deepdoctection/tp_casc_rcnn_X_32xd4_50_FPN_GN_2FC_publaynet",
             hf_model_name="model-800000",
             hf_config_file=["conf_frcnn_layout.yaml"],
+            dl_library="TF",
             categories={
                 "1": LayoutType.text,
                 "2": LayoutType.title,
@@ -170,6 +176,7 @@ class ModelCatalog:
             hf_model_name="model-1800000",
             hf_config_file=["conf_frcnn_cell.yaml"],
             categories={"1": LayoutType.cell},
+            dl_library="TF",
             model_wrapper="TPFrcnnDetector",
         ),
         "layout/d2_model-800000-layout.pkl": ModelProfile(
@@ -188,6 +195,7 @@ class ModelCatalog:
                 "4": LayoutType.table,
                 "5": LayoutType.figure,
             },
+            dl_library="PT",
             model_wrapper="D2FrcnnDetector",
         ),
         "layout/d2_model_0829999_layout_inf_only.pt": ModelProfile(
@@ -206,6 +214,7 @@ class ModelCatalog:
                 "4": LayoutType.table,
                 "5": LayoutType.figure,
             },
+            dl_library="PT",
             model_wrapper="D2FrcnnDetector",
         ),
         "layout/d2_model_0829999_layout.pth": ModelProfile(
@@ -224,6 +233,7 @@ class ModelCatalog:
                 "4": LayoutType.table,
                 "5": LayoutType.figure,
             },
+            dl_library="PT",
             model_wrapper="D2FrcnnDetector",
         ),
         "cell/d2_model-1800000-cell.pkl": ModelProfile(
@@ -236,6 +246,7 @@ class ModelCatalog:
             hf_model_name="d2_model-1800000-cell.pkl",
             hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
             categories={"1": LayoutType.cell},
+            dl_library="PT",
             model_wrapper="D2FrcnnDetector",
         ),
         "cell/d2_model_1849999_cell_inf_only.pt": ModelProfile(
@@ -248,6 +259,7 @@ class ModelCatalog:
             hf_model_name="d2_model_1849999_cell_inf_only.pt",
             hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
             categories={"1": LayoutType.cell},
+            dl_library="PT",
             model_wrapper="D2FrcnnDetector",
         ),
         "cell/d2_model_1849999_cell.pth": ModelProfile(
@@ -260,6 +272,7 @@ class ModelCatalog:
             hf_model_name="cell/d2_model_1849999_cell.pth",
             hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
             categories={"1": LayoutType.cell},
+            dl_library="PT",
             model_wrapper="D2FrcnnDetector",
         ),
         "item/d2_model-1620000-item.pkl": ModelProfile(
@@ -272,6 +285,7 @@ class ModelCatalog:
             hf_model_name="d2_model-1620000-item.pkl",
             hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
             categories={"1": LayoutType.row, "2": LayoutType.column},
+            dl_library="PT",
             model_wrapper="D2FrcnnDetector",
         ),
         "item/d2_model_1639999_item.pth": ModelProfile(
@@ -284,6 +298,7 @@ class ModelCatalog:
             hf_model_name="d2_model_1639999_item.pth",
             hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
             categories={"1": LayoutType.row, "2": LayoutType.column},
+            dl_library="PT",
             model_wrapper="D2FrcnnDetector",
         ),
         "item/d2_model_1639999_item_inf_only.pt": ModelProfile(
@@ -296,6 +311,7 @@ class ModelCatalog:
             hf_model_name="d2_model_1639999_item_inf_only.pt",
             hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
             categories={"1": LayoutType.row, "2": LayoutType.column},
+            dl_library="PT",
             model_wrapper="D2FrcnnDetector",
         ),
         "microsoft/layoutlm-base-uncased/pytorch_model.bin": ModelProfile(
@@ -311,6 +327,7 @@ class ModelCatalog:
             hf_repo_id="microsoft/layoutlm-base-uncased",
             hf_model_name="pytorch_model.bin",
             hf_config_file=["config.json"],
+            dl_library="PT",
         ),
         "microsoft/layoutlm-large-uncased/pytorch_model.bin": ModelProfile(
             name="microsoft/layoutlm-large-uncased/pytorch_model.bin",
@@ -325,6 +342,7 @@ class ModelCatalog:
             hf_repo_id="microsoft/layoutlm-large-uncased",
             hf_model_name="pytorch_model.bin",
             hf_config_file=["config.json"],
+            dl_library="PT",
         ),
         "microsoft/layoutlmv2-base-uncased/pytorch_model.bin": ModelProfile(
             name="microsoft/layoutlmv2-base-uncased/pytorch_model.bin",
@@ -340,6 +358,7 @@ class ModelCatalog:
             hf_repo_id="microsoft/layoutlmv2-base-uncased",
             hf_model_name="pytorch_model.bin",
             hf_config_file=["config.json"],
+            dl_library="PT",
         ),
         "microsoft/layoutxlm-base/pytorch_model.bin": ModelProfile(
             name="microsoft/layoutxlm-base/pytorch_model.bin",
@@ -359,6 +378,7 @@ class ModelCatalog:
             hf_repo_id="microsoft/layoutxlm-base",
             hf_model_name="pytorch_model.bin",
             hf_config_file=["config.json"],
+            dl_library="PT",
         ),
         "microsoft/layoutlmv3-base/pytorch_model.bin": ModelProfile(
             name="microsoft/layoutlmv3-base/pytorch_model.bin",
@@ -374,6 +394,7 @@ class ModelCatalog:
             hf_repo_id="microsoft/layoutlmv3-base",
             hf_model_name="pytorch_model.bin",
             hf_config_file=["config.json"],
+            dl_library="PT",
         ),
         "microsoft/table-transformer-detection/pytorch_model.bin": ModelProfile(
             name="microsoft/table-transformer-detection/pytorch_model.bin",
@@ -388,6 +409,7 @@ class ModelCatalog:
             hf_model_name="pytorch_model.bin",
             hf_config_file=["config.json", "preprocessor_config.json"],
             categories={"1": LayoutType.table},
+            dl_library="PT",
             model_wrapper="HFDetrDerivedDetector",
         ),
         "microsoft/table-transformer-structure-recognition/pytorch_model.bin": ModelProfile(
@@ -411,7 +433,41 @@ class ModelCatalog:
                 "5": CellType.projected_row_header,
                 "6": CellType.spanning,
             },
+            dl_library="PT",
             model_wrapper="HFDetrDerivedDetector",
+        ),
+        "doctr/db_resnet50/pt/db_resnet50-ac60cadc.pt": ModelProfile(
+            name="doctr/db_resnet50/pt/db_resnet50-ac60cadc.pt",
+            description="Doctr implementation of DBNet from “Real-time Scene Text Detection with Differentiable "
+                        "Binarization”. For more information please check "
+                        "https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Pytorch artefact.",
+            size=[101971449],
+            urls=["https://doctr-static.mindee.com/models?id=v0.3.1/db_resnet50-ac60cadc.pt&src=0"],
+            categories= {"1": LayoutType.word},
+            dl_library="PT",
+            model_wrapper="DoctrTextlineDetector",
+        ),
+        "doctr/db_resnet50/tf/db_resnet50-adcafc63.zip": ModelProfile(
+            name="doctr/db_resnet50/tf/db_resnet50-adcafc63.zip",
+            description="Doctr implementation of DBNet from “Real-time Scene Text Detection with Differentiable "
+                        "Binarization”. For more information please check "
+                        "https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Tensorflow artefact.",
+            size=[94178964],
+            urls=["https://doctr-static.mindee.com/models?id=v0.2.0/db_resnet50-adcafc63.zip&src=0"],
+            categories={"1": LayoutType.word},
+            dl_library="TF",
+            model_wrapper="DoctrTextlineDetector",
+        ),
+        "doctr/crnn_vgg16_bn/pt/crnn_vgg16_bn-9762b0b0.pt": ModelProfile(
+            name="doctr/crnn_vgg16_bn/pt/crnn_vgg16_bn-9762b0b0.pt",
+            description="Doctr implementation of CRNN from “An End-to-End Trainable Neural Network for Image-based "
+                        "Sequence Recognition and Its Application to Scene Text Recognition”. For more information "
+                        "please check https://mindee.github.io/doctr/using_doctr/using_models.html#. This is the Pytorch "
+                        "artefact.",
+            size=[63286381],
+            urls=["https://doctr-static.mindee.com/models?id=v0.3.1/crnn_vgg16_bn-9762b0b0.pt&src=0"],
+            dl_library="PT",
+            model_wrapper="DoctrTextRecognizer",
         ),
         "fasttext/lid.176.bin": ModelProfile(
             name="fasttext/lid.176.bin",
@@ -788,7 +844,7 @@ class ModelDownloadManager:
                     if profile.urls is None:
                         raise ValueError("hf_model_name and urls cannot be both None")
                     for url in profile.urls:
-                        file_names.append(url.split("/")[-1])
+                        file_names.append(url.split("/")[-1].split("&")[0])
                 else:
                     file_names.append(model_name)
             if profile.hf_repo_id:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ _DEPS = [
     "python-prctl",
     "pyyaml==6.0",
     "pyzmq>=16",
-    "rapidfuzz>=1.6.0,<3.0",
+    "rapidfuzz>=1.6.0,<3.0",  # we need this requirement for Doctr as long they have not fixed #1186 for v.0.6.0
     "termcolor>=1.1",
     "tabulate>=0.7.7",
     "tqdm==4.64.0",

--- a/tests/extern/test_doctrocr.py
+++ b/tests/extern/test_doctrocr.py
@@ -27,8 +27,8 @@ from pytest import mark
 
 from deepdoctection.extern.base import DetectionResult
 from deepdoctection.extern.doctrocr import DoctrTextlineDetector, DoctrTextRecognizer
+from deepdoctection.extern.model import ModelCatalog, ModelDownloadManager
 from deepdoctection.utils.detection_types import ImageType
-from deepdoctection.extern.model import ModelDownloadManager, ModelCatalog
 from tests.data import Annotations
 
 
@@ -67,9 +67,11 @@ class TestDoctrTextlineDetector:
         """
 
         # Arrange
-        path_weights = ModelDownloadManager.maybe_download_weights_and_configs("doctr/db_resnet50/pt/db_resnet50-ac60cadc.pt")
+        path_weights = ModelDownloadManager.maybe_download_weights_and_configs(
+            "doctr/db_resnet50/pt/db_resnet50-ac60cadc.pt"
+        )
         categories = ModelCatalog.get_profile("doctr/db_resnet50/pt/db_resnet50-ac60cadc.pt").categories
-        doctr = DoctrTextlineDetector("db_resnet50", path_weights, categories, "cpu") # type: ignore
+        doctr = DoctrTextlineDetector("db_resnet50", path_weights, categories, "cpu")  # type: ignore
 
         # Act
         results = doctr.predict(np_image)
@@ -86,9 +88,11 @@ class TestDoctrTextlineDetector:
         """
 
         # Arrange
-        path_weights = ModelDownloadManager.maybe_download_weights_and_configs("doctr/db_resnet50/tf/db_resnet50-adcafc63.zip")
+        path_weights = ModelDownloadManager.maybe_download_weights_and_configs(
+            "doctr/db_resnet50/tf/db_resnet50-adcafc63.zip"
+        )
         categories = ModelCatalog.get_profile("doctr/db_resnet50/tf/db_resnet50-adcafc63.zip").categories
-        doctr = DoctrTextlineDetector("db_resnet50", path_weights, categories, "cpu") # type: ignore
+        doctr = DoctrTextlineDetector("db_resnet50", path_weights, categories, "cpu")  # type: ignore
 
         # Act
         results = doctr.predict(np_image)
@@ -111,7 +115,9 @@ class TestDoctrTextRecognizer:
         """
 
         # Arrange
-        path_weights = ModelDownloadManager.maybe_download_weights_and_configs("doctr/crnn_vgg16_bn/pt/crnn_vgg16_bn-9762b0b0.pt")
+        path_weights = ModelDownloadManager.maybe_download_weights_and_configs(
+            "doctr/crnn_vgg16_bn/pt/crnn_vgg16_bn-9762b0b0.pt"
+        )
         doctr = DoctrTextRecognizer("crnn_vgg16_bn", path_weights, "cpu")
 
         # Act
@@ -129,7 +135,9 @@ class TestDoctrTextRecognizer:
         """
 
         # Arrange
-        path_weights = ModelDownloadManager.maybe_download_weights_and_configs("doctr/crnn_vgg16_bn/tf/crnn_vgg16_bn-76b7f2c6.zip")
+        path_weights = ModelDownloadManager.maybe_download_weights_and_configs(
+            "doctr/crnn_vgg16_bn/tf/crnn_vgg16_bn-76b7f2c6.zip"
+        )
         doctr = DoctrTextRecognizer("crnn_vgg16_bn", path_weights, "cpu")
 
         # Act

--- a/tests/extern/test_doctrocr.py
+++ b/tests/extern/test_doctrocr.py
@@ -28,10 +28,11 @@ from pytest import mark
 from deepdoctection.extern.base import DetectionResult
 from deepdoctection.extern.doctrocr import DoctrTextlineDetector, DoctrTextRecognizer
 from deepdoctection.utils.detection_types import ImageType
+from deepdoctection.extern.model import ModelDownloadManager, ModelCatalog
 from tests.data import Annotations
 
 
-def get_mock_word_results(np_img: ImageType, predictor) -> List[DetectionResult]:  # type: ignore  # pylint: disable=W0613
+def get_mock_word_results(np_img: ImageType, predictor, device) -> List[DetectionResult]:  # type: ignore  # pylint: disable=W0613
     """
     Returns WordResults attr: word_results_list
     """
@@ -39,7 +40,7 @@ def get_mock_word_results(np_img: ImageType, predictor) -> List[DetectionResult]
 
 
 def get_mock_text_line_results(  # type: ignore
-    inputs: List[Tuple[str, ImageType]], predictor  # pylint: disable=W0613
+    inputs: List[Tuple[str, ImageType]], predictor, device  # pylint: disable=W0613
 ) -> List[DetectionResult]:
 
     """
@@ -58,15 +59,36 @@ class TestDoctrTextlineDetector:
     """
 
     @staticmethod
-    @mark.requires_tf_or_pt
+    @mark.requires_pt
     @patch("deepdoctection.extern.doctrocr.doctr_predict_text_lines", MagicMock(side_effect=get_mock_word_results))
-    def test_doctr__detector_predicts_image(np_image: ImageType) -> None:
+    def test_pt_doctr_detector_predicts_image(np_image: ImageType) -> None:
+        """
+        Detector calls doctr_predict_text_lines. Only runs in pt environment
+        """
+
+        # Arrange
+        path_weights = ModelDownloadManager.maybe_download_weights_and_configs("doctr/db_resnet50/pt/db_resnet50-ac60cadc.pt")
+        categories = ModelCatalog.get_profile("doctr/db_resnet50/pt/db_resnet50-ac60cadc.pt").categories
+        doctr = DoctrTextlineDetector("db_resnet50", path_weights, categories, "cpu") # type: ignore
+
+        # Act
+        results = doctr.predict(np_image)
+
+        # Assert
+        assert len(results) == 2
+
+    @staticmethod
+    @mark.requires_tf
+    @patch("deepdoctection.extern.doctrocr.doctr_predict_text_lines", MagicMock(side_effect=get_mock_word_results))
+    def test_tf_doctr_detector_predicts_image(np_image: ImageType) -> None:
         """
         Detector calls doctr_predict_text_lines. Only runs in tf environment
         """
 
         # Arrange
-        doctr = DoctrTextlineDetector()
+        path_weights = ModelDownloadManager.maybe_download_weights_and_configs("doctr/db_resnet50/tf/db_resnet50-adcafc63.zip")
+        categories = ModelCatalog.get_profile("doctr/db_resnet50/tf/db_resnet50-adcafc63.zip").categories
+        doctr = DoctrTextlineDetector("db_resnet50", path_weights, categories, "cpu") # type: ignore
 
         # Act
         results = doctr.predict(np_image)
@@ -81,15 +103,34 @@ class TestDoctrTextRecognizer:
     """
 
     @staticmethod
-    @mark.requires_tf_or_pt
+    @mark.requires_pt
     @patch("deepdoctection.extern.doctrocr.doctr_predict_text", MagicMock(side_effect=get_mock_text_line_results))
-    def test_doctr_recognizer_predicts_text(text_lines: List[Tuple[str, ImageType]]) -> None:
+    def test_doctr_pt_recognizer_predicts_text(text_lines: List[Tuple[str, ImageType]]) -> None:
+        """
+        Detector calls doctr_predict_text. Only runs in pt environment
+        """
+
+        # Arrange
+        path_weights = ModelDownloadManager.maybe_download_weights_and_configs("doctr/crnn_vgg16_bn/pt/crnn_vgg16_bn-9762b0b0.pt")
+        doctr = DoctrTextRecognizer("crnn_vgg16_bn", path_weights, "cpu")
+
+        # Act
+        results = doctr.predict(text_lines)
+
+        # Assert
+        assert len(results) == 2
+
+    @staticmethod
+    @mark.requires_tf
+    @patch("deepdoctection.extern.doctrocr.doctr_predict_text", MagicMock(side_effect=get_mock_text_line_results))
+    def test_doctr_tf_recognizer_predicts_text(text_lines: List[Tuple[str, ImageType]]) -> None:
         """
         Detector calls doctr_predict_text. Only runs in tf environment
         """
 
         # Arrange
-        doctr = DoctrTextRecognizer()
+        path_weights = ModelDownloadManager.maybe_download_weights_and_configs("doctr/crnn_vgg16_bn/tf/crnn_vgg16_bn-76b7f2c6.zip")
+        doctr = DoctrTextRecognizer("crnn_vgg16_bn", path_weights, "cpu")
 
         # Act
         results = doctr.predict(text_lines)


### PR DESCRIPTION
Previously, the DocTr `DoctrTextlineDetector` and `DoctrTextRecognizer` model wrapper only allowed loading the default architecture.

In this PR the arguments `architecture`, `path_weights`  as well as `device` have been added for both wrappers, so that custom weights can be loaded for Tensorflow and Torch. 

Furthermore, the pre-trained models `db_resnet50` and `crnn_vgg16_bn` were added to the model catalog. This makes use of the doctr cache obsolete.