### PR TITLE
remove unused package LegacyVersion and unused variables

### DIFF
--- a/deepdoctection/utils/__init__.py
+++ b/deepdoctection/utils/__init__.py
@@ -53,14 +53,3 @@ _global_import(
     "settings", suffix=("Type", "TokenClasses", "BioTag", "TokenClassWithTag", "Relationships", "Languages", "get_type")
 )
 
-# pylint: disable=undefined-variable
-__all__.extend(context.__all__)  # type: ignore
-__all__.extend(fs.__all__)  # type: ignore
-__all__.extend(identifier.__all__)  # type: ignore
-__all__.extend(["logger", "set_logger_dir", "auto_set_dir", "get_logger_dir"])
-__all__.extend(pdf_utils.__all__)  # type: ignore
-__all__.extend(systools.__all__)  # type: ignore
-__all__.extend(["get_tqdm"])
-__all__.extend(transform.__all__)  # type: ignore
-__all__.extend(viz.__all__)  # type: ignore
-# pylint: enable=undefined-variable

--- a/deepdoctection/utils/file_utils.py
+++ b/deepdoctection/utils/file_utils.py
@@ -292,7 +292,7 @@ class TesseractNotFound(BaseException):
     """
 
 
-def get_tesseract_version() -> Union[int, version.Version, version.LegacyVersion]:
+def get_tesseract_version() -> Union[int, version.Version]:
     """
     Returns Version object of the Tesseract version. We need at least Tesseract 3.05
     """
@@ -352,7 +352,7 @@ class PopplerNotFound(BaseException):
     """
 
 
-def get_poppler_version() -> Union[int, version.Version, version.LegacyVersion]:
+def get_poppler_version() -> Union[int, version.Version]:
     """
     Returns Version object of the Poppler version. We need at least Tesseract 3.05
     """


### PR DESCRIPTION
Fresh install of deepdoctection results into missing legacyVersion error and unused variables.

AttributeError: module 'packaging.version' has no attribute 'legacyVersion'
![image](https://github.com/deepdoctection/deepdoctection/assets/6997299/c1f0ff28-a652-4955-8f2b-8d4fa0ac554b)

NameError: name 'context' is not defined
![image](https://github.com/deepdoctection/deepdoctection/assets/6997299/cc06e1d9-3434-48ee-9e67-56b4d35efd89)

Closes #178