### PR TITLE
Fix _load_model loading errors when cfg.LIB=="TF" and DocTr is used

### DIFF
--- a/deepdoctection/analyzer/dd.py
+++ b/deepdoctection/analyzer/dd.py
@@ -225,7 +225,7 @@ def _build_doctr_word(cfg: AttrDict) -> DoctrTextlineDetector:
         raise ValueError("model profile.architecture must be specified")
     if profile.categories is None:
         raise ValueError("model profile.categories must be specified")
-    return DoctrTextlineDetector(profile.architecture, weights_path, profile.categories, cfg.DEVICE)
+    return DoctrTextlineDetector(profile.architecture, weights_path, profile.categories, cfg.DEVICE, lib=cfg.LIB)
 
 
 def build_analyzer(cfg: AttrDict) -> DoctectionPipe:

--- a/deepdoctection/analyzer/dd.py
+++ b/deepdoctection/analyzer/dd.py
@@ -206,7 +206,7 @@ def _build_ocr(cfg: AttrDict) -> Union[TesseractOcrDetector, DoctrTextRecognizer
         profile = ModelCatalog.get_profile(weights)
         if profile.architecture is None:
             raise ValueError("model profile.architecture must be specified")
-        return DoctrTextRecognizer(profile.architecture, weights_path, cfg.DEVICE)
+        return DoctrTextRecognizer(profile.architecture, weights_path, cfg.DEVICE, lib=cfg.LIB)
     if cfg.OCR.USE_TEXTRACT:
         credentials_kwargs = {
             "aws_access_key_id": environ.get("ACCESS_KEY"),

--- a/deepdoctection/extern/doctrocr.py
+++ b/deepdoctection/extern/doctrocr.py
@@ -173,7 +173,7 @@ class DoctrTextlineDetector(ObjectDetector):
         path_weights: str,
         categories: Mapping[str, TypeOrStr],
         device: Optional[Literal["cpu", "cuda"]] = None,
-        lib:str = "TF"
+        lib: str = "TF"
     ) -> None:
         self.lib = lib
         self.name = "doctr_text_detector"
@@ -254,7 +254,8 @@ class DoctrTextRecognizer(TextRecognizer):
 
     """
 
-    def __init__(self, architecture: str, path_weights: str, device: Optional[Literal["cpu", "cuda"]] = None) -> None:
+    def __init__(self, architecture: str, path_weights: str, device: Optional[Literal["cpu", "cuda"]] = None, lib: str = "TF") -> None:
+        self.lib = lib
         self.name = "doctr_text_recognizer"
         self.architecture = architecture
         self.path_weights = path_weights
@@ -287,4 +288,4 @@ class DoctrTextRecognizer(TextRecognizer):
 
     def load_model(self) -> None:
         """Loading model weights"""
-        _load_model(self.path_weights, self.doctr_predictor, self.device)
+        _load_model(self.path_weights, self.doctr_predictor, self.device, self.lib)

--- a/deepdoctection/extern/doctrocr.py
+++ b/deepdoctection/extern/doctrocr.py
@@ -62,14 +62,14 @@ def _set_device_str(device: Optional[str] = None) -> str:
     return device
 
 
-def _load_model(path_weights: str, doctr_predictor: Any, device: str) -> None:
-    if pytorch_available():
+def _load_model(path_weights: str, doctr_predictor: Any, device: str, lib: str) -> None:
+    if lib == "PT" and pytorch_available():
         state_dict = torch.load(path_weights, map_location=device)
         for key in list(state_dict.keys()):
             state_dict["model." + key] = state_dict.pop(key)
         doctr_predictor.load_state_dict(state_dict)
         doctr_predictor.to(device)
-    elif tf_available():
+    elif lib == "TF" and tf_available():
         # Unzip the archive
         params_path = Path(path_weights).parent
         is_zip_path = path_weights.endswith(".zip")
@@ -173,7 +173,9 @@ class DoctrTextlineDetector(ObjectDetector):
         path_weights: str,
         categories: Mapping[str, TypeOrStr],
         device: Optional[Literal["cpu", "cuda"]] = None,
+        lib:str = "TF"
     ) -> None:
+        self.lib = lib
         self.name = "doctr_text_detector"
         self.architecture = architecture
         self.path_weights = path_weights


### PR DESCRIPTION
When pytorch and tensorflow are available at the same time and cfg.LIB=="TF", the use of doctr will load the zip model file of tensorflow by torch.load in _load_model.