### PR TITLE
Add additional attribute names

### DIFF
--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -415,6 +415,17 @@ class Page(Image):
     text_container: ObjectTypes
     floating_text_block_categories: List[ObjectTypes]
     image_orig: Image
+    _attribute_names: Set[str] = {
+        "text",
+        "chunks",
+        "tables",
+        "layouts",
+        "words",
+        "file_name",
+        "location",
+        "document_id",
+        "page_number",
+    }
 
     @no_type_check
     def get_annotation(
@@ -744,24 +755,32 @@ class Page(Image):
             return img
         return None
 
-    @staticmethod
-    def get_attribute_names() -> Set[str]:
+    @classmethod
+    def get_attribute_names(cls) -> Set[str]:
         """
         :return: A set of registered attributes.
         """
-        return set(PageType).union(
-            {
-                "text",
-                "chunks",
-                "tables",
-                "layouts",
-                "words",
-                "file_name",
-                "location",
-                "document_id",
-                "page_number",
-            }
-        )
+        return set(PageType).union(cls._attribute_names)
+
+    @classmethod
+    def add_attribute_name(cls, attribute_name: Union[str, ObjectTypes]) -> None:
+        """
+        Adding a custom attribute name to a Page class.
+
+                **Example:**
+
+                Page.add_attribute_name("foo")
+
+                page = Page.from_image(...)
+                print(page.foo)
+
+        Note, that the attribute must be registered as a valid `ObjectTypes`
+
+        :param attribute_name: attribute name to add
+        """
+
+        attribute_name = get_type(attribute_name)
+        cls._attribute_names.add(attribute_name.value)
 
     def save(
         self,

--- a/deepdoctection/extern/tp/tpfrcnn/modeling/model_fpn.py
+++ b/deepdoctection/extern/tp/tpfrcnn/modeling/model_fpn.py
@@ -63,7 +63,9 @@ def fpn_model(features, fpn_num_channels, fpn_norm):
                 x = tf.transpose(x, [0, 3, 1, 2])
                 return x
         except AttributeError:
-            return FixedUnPooling(name, x, 2, unpool_mat=np.ones((2, 2), dtype="float32"), data_format="channels_first")  # pylint: disable=E1124
+            return FixedUnPooling(
+                name, x, 2, unpool_mat=np.ones((2, 2), dtype="float32"), data_format="channels_first"
+            )  # pylint: disable=E1124
 
     with argscope(
         Conv2D,
@@ -85,7 +87,9 @@ def fpn_model(features, fpn_num_channels, fpn_norm):
         p2345 = [Conv2D(f"posthoc_3x3_p{i + 2}", c, num_channel, 3) for i, c in enumerate(lat_sum_5432[::-1])]
         if use_gn:
             p2345 = [GroupNorm(f"gn_p{i + 2}", c) for i, c in enumerate(p2345)]
-        p6 = MaxPooling("maxpool_p6", p2345[-1], pool_size=1, strides=2, data_format="channels_first", padding="VALID")  # pylint: disable=E1124
+        p6 = MaxPooling(
+            "maxpool_p6", p2345[-1], pool_size=1, strides=2, data_format="channels_first", padding="VALID"
+        )  # pylint: disable=E1124
         return p2345 + [p6]
 
 

--- a/deepdoctection/extern/tp/tpfrcnn/modeling/model_frcnn.py
+++ b/deepdoctection/extern/tp/tpfrcnn/modeling/model_frcnn.py
@@ -267,8 +267,10 @@ def fastrcnn_2fc_head(feature, cfg):
 
     dim = cfg.FPN.FRCNN_FC_HEAD_DIM
     init = tfv1.variance_scaling_initializer()
-    hidden = FullyConnected("fc6", feature, dim, kernel_initializer=init, activation=tf.nn.relu)   # pylint: disable=E1124
-    hidden = FullyConnected("fc7", hidden, dim, kernel_initializer=init, activation=tf.nn.relu)    # pylint: disable=E1124
+    hidden = FullyConnected(
+        "fc6", feature, dim, kernel_initializer=init, activation=tf.nn.relu
+    )  # pylint: disable=E1124
+    hidden = FullyConnected("fc7", hidden, dim, kernel_initializer=init, activation=tf.nn.relu)  # pylint: disable=E1124
     return hidden
 
 

--- a/deepdoctection/extern/tp/tpfrcnn/modeling/model_mrcnn.py
+++ b/deepdoctection/extern/tp/tpfrcnn/modeling/model_mrcnn.py
@@ -88,7 +88,9 @@ def maskrcnn_upXconv_head(feature, num_category, num_convs, norm=None, **kwargs)
             l = Conv2D(f"fcn{k}", l, cfg.MRCNN.HEAD_DIM, 3, activation=tf.nn.relu)
             if norm is not None:
                 l = GroupNorm(f"gn{k}", l)
-        l = Conv2DTranspose("deconv", l, cfg.MRCNN.HEAD_DIM, 2, strides=2, activation=tf.nn.relu)  # pylint: disable=E1124
+        l = Conv2DTranspose(
+            "deconv", l, cfg.MRCNN.HEAD_DIM, 2, strides=2, activation=tf.nn.relu
+        )  # pylint: disable=E1124
         l = Conv2D("conv", l, num_category, 1, kernel_initializer=tf.random_normal_initializer(stddev=0.001))
     return l
 


### PR DESCRIPTION
This PR allows to add new attribute names to the `Page`, provided these attributes are regularly registered as `ObjectTypes`.