### PR TITLE
Handle relative coords when mapping into Detectron2 structure

### DIFF
--- a/deepdoctection/datapoint/image.py
+++ b/deepdoctection/datapoint/image.py
@@ -19,6 +19,7 @@
 Dataclass Image
 """
 import json
+from os import environ
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Union, no_type_check
@@ -147,7 +148,7 @@ class Image:
             self.set_width_height(self._image.shape[1], self._image.shape[0])
             self._self_embedding()
         elif isinstance(image, bytes):
-            self._image = convert_pdf_bytes_to_np_array_v2(image, dpi=300)
+            self._image = convert_pdf_bytes_to_np_array_v2(image, dpi=environ.get("DPI", 300))
             self.set_width_height(self._image.shape[1], self._image.shape[0])
             self._self_embedding()
         else:

--- a/deepdoctection/mapper/d2struct.py
+++ b/deepdoctection/mapper/d2struct.py
@@ -86,6 +86,10 @@ def image_to_d2_frcnn_training(
             box = ann.bounding_box
         if box is None:
             raise ValueError("BoundingBox cannot be None")
+        if not box.absolute_coords:
+            box = box.transform(dp.width,dp.height,absolute_coords=True)
+
+        # Detectron2 does not fully support BoxMode.XYXY_REL
         mapped_ann: Dict[str, Union[str, int, List[float]]] = {
             "bbox_mode": BoxMode.XYXY_ABS,
             "bbox": box.to_list(mode="xyxy"),


### PR DESCRIPTION
This PR handles relative coords when mapping into Detectron2 annotation structure. 
It also makes DPI an environment variable.