### PR TITLE
Device detection to work with macbooks out of the box.

### DIFF
--- a/deepdoctection/train/hf_layoutlm_train.py
+++ b/deepdoctection/train/hf_layoutlm_train.py
@@ -62,6 +62,7 @@ from ..mapper.laylmstruct import LayoutLMDataCollator, image_to_raw_layoutlm_fea
 from ..pipe.base import LanguageModelPipelineComponent
 from ..pipe.lm import get_tokenizer_from_architecture
 from ..pipe.registry import pipeline_component_registry
+from ..utils.device_detection import detect_device
 from ..utils.file_utils import wandb_available
 from ..utils.logger import logger
 from ..utils.settings import DatasetType, LayoutType, ObjectTypes, WordType
@@ -462,7 +463,7 @@ def train_hf_layoutlm(
             path_config_json=path_config_json,
             path_weights=path_weights,
             categories=categories,
-            device="cuda",
+            device=detect_device(),
         )
         pipeline_component_cls = pipeline_component_registry.get(pipeline_component_name)
         if dataset_type == DatasetType.sequence_classification:

--- a/deepdoctection/utils/device_detection.py
+++ b/deepdoctection/utils/device_detection.py
@@ -1,0 +1,15 @@
+from torch import cuda, backends
+
+def detect_device():
+
+    device_checks = {
+        cuda.is_available: "cuda",
+        backends.mps.is_available: "mps",
+    }
+
+    for check in device_checks:
+        if check():
+            return device_checks[check]
+
+    else:
+        raise ValueError(f'Device not found in {list(device_checks.values())}')


### PR DESCRIPTION
The LayoutML integration would only work with a 'cuda' device. 
Added a new util to detect between the 'cuda' and 'mps'. 

Changed the LayoutML training function to work with the util.