### PR TITLE
Reducing log warnings in text ordering and table refinement process.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ snippets.py
 /snipptes.py
 /build/
 /wandb/
+.env

--- a/deepdoctection/__init__.py
+++ b/deepdoctection/__init__.py
@@ -5,6 +5,16 @@
 Init file for deepdoctection package
 """
 
+import importlib.util
+
+# Before doing anything else, check if the .env file exists and load it
+if importlib.util.find_spec("dotenv") is not None:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+
+# pylint: disable=wrong-import-position
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -14,6 +24,8 @@ from packaging import version
 from .utils.env_info import auto_select_lib_and_device
 from .utils.file_utils import _LazyModule, get_tf_version, pytorch_available, tf_available
 from .utils.logger import logger
+
+# pylint: enable=wrong-import-position
 
 __version__ = 0.27
 

--- a/deepdoctection/configs/conf_dd_one.yaml
+++ b/deepdoctection/configs/conf_dd_one.yaml
@@ -74,7 +74,7 @@ WORD_MATCHING:
     - row_header
   RULE: ioa
   THRESHOLD: 0.6
-  MAX_PARENT_ONLY: False
+  MAX_PARENT_ONLY: True
 TEXT_ORDERING:
   TEXT_BLOCK_CATEGORIES:
     - title

--- a/deepdoctection/mapper/d2struct.py
+++ b/deepdoctection/mapper/d2struct.py
@@ -121,6 +121,11 @@ def pt_nms_image_annotations(
     """
     if len(anns) == 1:
         return [anns[0].annotation_id]
+
+    # if all annotations are the same and prio is set, we need to return all annotation ids
+    if prio and all(ann.category_name == anns[0].category_name for ann in anns):
+        return [ann.annotation_id for ann in anns]
+
     if not anns:
         return []
     ann_ids = np.array([ann.annotation_id for ann in anns], dtype="object")

--- a/deepdoctection/pipe/order.py
+++ b/deepdoctection/pipe/order.py
@@ -516,7 +516,10 @@ class TextOrderService(PipelineComponent):
                 text_block_anns.extend(residual_text_container_anns)
         for text_block_ann in text_block_anns:
             self.order_text_in_text_block(text_block_ann)
-        self.order_blocks(text_block_anns)
+        floating_text_block_anns_to_order = [
+            ann for ann in text_block_anns if ann.category_name in self.floating_text_block_categories
+        ]
+        self.order_blocks(floating_text_block_anns_to_order)
 
     def _create_lines_for_words(self, word_anns: Sequence[ImageAnnotation]) -> Sequence[ImageAnnotation]:
         detection_result_list = self.text_line_generator.create_detection_result(
@@ -544,7 +547,9 @@ class TextOrderService(PipelineComponent):
         :param text_block_ann: text block annotation (category one of `text_block_categories`).
         """
         text_container_ids = text_block_ann.get_relationship(Relationships.child)
-        text_container_ann = self.dp_manager.datapoint.get_annotation(annotation_ids=text_container_ids)
+        text_container_ann = self.dp_manager.datapoint.get_annotation(
+            annotation_ids=text_container_ids, category_names=self.text_container
+        )
         if self.text_container == LayoutType.word:
             word_order_list = self.order_generator.group_words_into_lines(
                 text_container_ann, self.dp_manager.datapoint.image_id

--- a/deepdoctection/pipe/refine.py
+++ b/deepdoctection/pipe/refine.py
@@ -465,14 +465,15 @@ class TableSegmentationRefinementService(PipelineComponent):
             max_row_span = max(int(cell.get_sub_category(CellType.row_span).category_id) for cell in cells)
             max_col_span = max(int(cell.get_sub_category(CellType.column_span).category_id) for cell in cells)
             # TODO: the summaries should be sub categories of the underlying ann
-            if TableType.number_of_rows in table.sub_categories:
-                table.remove_sub_category(TableType.number_of_rows)
-            if TableType.number_of_columns in table.sub_categories:
-                table.remove_sub_category(TableType.number_of_columns)
-            if TableType.max_row_span in table.sub_categories:
-                table.remove_sub_category(TableType.max_row_span)
-            if TableType.max_col_span in table.sub_categories:
-                table.remove_sub_category(TableType.max_col_span)
+            if table.image.summary is not None:
+                if TableType.number_of_rows in table.image.summary.sub_categories:
+                    table.image.summary.remove_sub_category(TableType.number_of_rows)
+                if TableType.number_of_columns in table.image.summary.sub_categories:
+                    table.image.summary.remove_sub_category(TableType.number_of_columns)
+                if TableType.max_row_span in table.image.summary.sub_categories:
+                    table.image.summary.remove_sub_category(TableType.max_row_span)
+                if TableType.max_col_span in table.image.summary.sub_categories:
+                    table.image.summary.remove_sub_category(TableType.max_col_span)
 
             self.dp_manager.set_summary_annotation(
                 TableType.number_of_rows, TableType.number_of_rows, number_of_rows, annotation_id=table.annotation_id

--- a/deepdoctection/utils/env_info.py
+++ b/deepdoctection/utils/env_info.py
@@ -16,7 +16,34 @@
 # limitations under the License.
 
 """
-Some useful function for collecting environment information
+Some useful function for collecting environment information.
+
+This is also the place where we give an overview of the important environment variables.
+
+`USE_TENSORFLOW
+USE_PYTORCH
+USE_CUDA
+USE_MPS`
+
+are responsible for selecting the predictors based on the installed DL framework and available devices.
+It is not recommended to touch them.
+
+`USE_PILLOW
+USE_OPENCV`
+
+decide what image processing library the `viz_handler` should use. The default library is PIL and OpenCV need
+to be installed separately. However, if both libraries have been detected `viz_handler` will opt for OpenCV.
+Use the variables to let choose `viz_handler` according to your preferences.
+
+`HF_CREDENTIALS`
+
+will be used by the `ModelDownloadManager` to pass your credentials if you have a model registered that resides in a
+private repo.
+
+`MODEL_CATALOG`
+
+can store an (absolute) path to a `.jsonl` file.
+
 """
 
 import ast

--- a/deepdoctection/utils/logger.py
+++ b/deepdoctection/utils/logger.py
@@ -20,6 +20,9 @@ The logger module itself has the common logging functions of Python's
         logger.info("Something has happened")
         logger.warning("Attention!")
         logger.error("Error happened!")
+
+Log levels can be set via the environment variable `LOG_LEVEL` (default: INFO).
+`STD_OUT_VERBOSE` will print a verbose message to the terminal (default: False).
 """
 
 import errno
@@ -63,10 +66,16 @@ class CustomFilter(logging.Filter):
 class StreamFormatter(logging.Formatter):
     """A custom formatter to produce unified LogRecords"""
 
+    std_out_verbose = os.environ.get("STD_OUT_VERBOSE", "False")
+
     @no_type_check
     def format(self, record: logging.LogRecord) -> str:
         date = colored("[%(asctime)s @%(filename)s:%(lineno)d]", "green")
         msg = colored("%(message)s", "white")
+
+        if self.std_out_verbose:
+            log_dict = getattr(record, "log_dict", "")
+            msg = f"{msg}. Additional verbose infos: {repr(log_dict)}"
 
         if record.levelno == logging.WARNING:
             fmt = f"{date}  {colored('WRN', 'magenta', attrs=['blink'])}  {msg}"
@@ -111,7 +120,7 @@ _CONFIG_DICT: Dict[str, Any] = {
     "handlers": {
         "streamhandler": {"filters": ["customfilter"], "formatter": "streamformatter", "class": "logging.StreamHandler"}
     },
-    "root": {"handlers": ["streamhandler"], "level": "INFO", "propagate": False},
+    "root": {"handlers": ["streamhandler"], "level": os.environ.get("LOG_LEVEL", "INFO"), "propagate": False},
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ _DEPS = [
     "python-doctr==0.7.0",
     "fasttext",
     # dev dependencies
+    "python-dotenv==1.0.0",
     "click",  # version will not break black
     "black==23.7.0",
     "isort",
@@ -183,6 +184,7 @@ test_deps = deps_list("pytest", "pytest-cov")
 
 # dev dependencies
 dev_deps = deps_list(
+    "python-dotenv",
     "click",
     "black",
     "isort",


### PR DESCRIPTION
This PR fixes #168 and reduces the amount of warnings in text ordering and table recognition refinement. 
It also adds some small features:

- add an environment variable for verbose logging
- add models from file to ModelCatalog