### PR TITLE
Loading 2-dim images with Pillow

### DIFF
--- a/deepdoctection/analyzer/dd.py
+++ b/deepdoctection/analyzer/dd.py
@@ -245,7 +245,7 @@ def build_ocr(cfg: AttrDict) -> Union[TesseractOcrDetector, DoctrTextRecognizer,
 
 
 def build_doctr_word(cfg: AttrDict) -> DoctrTextlineDetector:
-    """Building `DoctrTextlineDetector` instance """
+    """Building `DoctrTextlineDetector` instance"""
     weights = cfg.OCR.WEIGHTS.DOCTR_WORD.TF if cfg.LIB == "TF" else cfg.OCR.WEIGHTS.DOCTR_WORD.PT
     weights_path = ModelDownloadManager.maybe_download_weights_and_configs(weights)
     profile = ModelCatalog.get_profile(weights)

--- a/deepdoctection/datasets/save.py
+++ b/deepdoctection/datasets/save.py
@@ -87,7 +87,7 @@ def dataflow_to_json(
                 viz_handler.write_image(str(target_file_png), image)
 
             with open(target_file, "w", encoding="UTF-8") as file:
-                json.dump(dp, file)
+                json.dump(dp, file, indent=2)
 
     else:
         if not file_name:

--- a/deepdoctection/utils/env_info.py
+++ b/deepdoctection/utils/env_info.py
@@ -28,8 +28,8 @@ USE_MPS`
 are responsible for selecting the predictors based on the installed DL framework and available devices.
 It is not recommended to touch them.
 
-`USE_PILLOW
-USE_OPENCV`
+`USE_DD_PILLOW
+USE_DD_OPENCV`
 
 decide what image processing library the `viz_handler` should use. The default library is PIL and OpenCV need
 to be installed separately. However, if both libraries have been detected `viz_handler` will opt for OpenCV.
@@ -521,12 +521,16 @@ def get_device(ignore_cpu: bool = True) -> str:
 
 def auto_select_viz_library() -> None:
     """Setting PIL as default image library if cv2 is not installed"""
+
+    # if env variables are already set, don't change them
+    if os.environ.get("USE_DD_PILLOW") or os.environ.get("USE_DD_OPENCV"):
+        return
     if opencv_available():
-        os.environ["USE_PILLOW"] = "False"
-        os.environ["USE_OPENCV"] = "True"
+        os.environ["USE_DD_PILLOW"] = "False"
+        os.environ["USE_DD_OPENCV"] = "True"
     else:
-        os.environ["USE_PILLOW"] = "True"
-        os.environ["USE_OPENCV"] = "False"
+        os.environ["USE_DD_PILLOW"] = "True"
+        os.environ["USE_DD_OPENCV"] = "False"
 
 
 # pylint: enable=import-outside-toplevel

--- a/deepdoctection/utils/viz.py
+++ b/deepdoctection/utils/viz.py
@@ -385,7 +385,7 @@ class VizPackageHandler:
 
     @staticmethod
     def _pillow_read_image(path: str) -> ImageType:
-        with Image.open(path) as image:
+        with Image.open(path).convert("RGB") as image:
             np_image = np.array(image)[:, :, ::-1]
         return np_image
 

--- a/deepdoctection/utils/viz.py
+++ b/deepdoctection/utils/viz.py
@@ -328,8 +328,8 @@ class VizPackageHandler:
         Otherwise it will use Pillow as default package
         :return: either 'pillow' or 'cv2'
         """
-        maybe_cv2 = "cv2" if ast.literal_eval(os.environ.get("USE_DD_OPENCV","False")) else None
-        maybe_pil = "pillow" if ast.literal_eval(os.environ.get("USE_DD_PILLOW","True")) else None
+        maybe_cv2 = "cv2" if ast.literal_eval(os.environ.get("USE_DD_OPENCV", "False")) else None
+        maybe_pil = "pillow" if ast.literal_eval(os.environ.get("USE_DD_PILLOW", "True")) else None
 
         if not maybe_cv2 and not maybe_pil:
             raise EnvironmentError(

--- a/deepdoctection/utils/viz.py
+++ b/deepdoctection/utils/viz.py
@@ -328,9 +328,8 @@ class VizPackageHandler:
         Otherwise it will use Pillow as default package
         :return: either 'pillow' or 'cv2'
         """
-
-        maybe_cv2 = "cv2" if ast.literal_eval(os.environ.get("USE_OPENCV", "False")) else None
-        maybe_pil = "pillow" if ast.literal_eval(os.environ.get("USE_PILLOW", "True")) else None
+        maybe_cv2 = "cv2" if ast.literal_eval(os.environ.get("USE_DD_OPENCV","False")) else None
+        maybe_pil = "pillow" if ast.literal_eval(os.environ.get("USE_DD_PILLOW","True")) else None
 
         if not maybe_cv2 and not maybe_pil:
             raise EnvironmentError(

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ _DEPS = [
     # PyTorch related dependencies
     "timm",
     "transformers",
+    "accelerate",
     # As maintenance of Detectron2 decreases, we will now use our own Fork the keep updating after rigorous testing.
     # This will hopefully prevent from issues like 233
     "detectron2 @ git+https://github.com/deepdoctection/detectron2.git",
@@ -150,7 +151,7 @@ additional_deps = deps_list(
 tf_deps = deps_list("tensorpack", "protobuf", "tensorflow-addons", "tf2onnx", "python-doctr", "pycocotools")
 
 # PyTorch dependencies
-pt_deps = deps_list("timm", "transformers", "python-doctr")
+pt_deps = deps_list("timm", "transformers", "accelerate", "python-doctr")
 
 source_pt_deps = pt_deps + deps_list("detectron2 @ git+https://github.com/deepdoctection/detectron2.git")
 
@@ -168,6 +169,7 @@ docs_deps = deps_list(
     "tensorpack",
     "boto3",
     "transformers",
+    "accelerate",
     "pdfplumber",
     "lxml",
     "lxml-stubs",

--- a/tests/analyzer/test_dd.py
+++ b/tests/analyzer/test_dd.py
@@ -159,7 +159,7 @@ def test_dd_analyzer_with_tatr() -> None:
     # 9 for d2 and 10 for tp model
     assert not page.layouts
     assert len(page.tables) == 1
-    assert len(page.tables[0].cells) in {11, 13}  # type: ignore
+    assert len(page.tables[0].cells) in {11, 13, 16}  # type: ignore
 
 
 @mark.integration_additional

--- a/tests/pipe/test_text.py
+++ b/tests/pipe/test_text.py
@@ -180,7 +180,7 @@ class TestTextExtractionServiceWithSubImage:
         assert global_box_sta == word_box_global[1]
         local_box_sta = second_word_ann.get_bounding_box(first_table_ann.annotation_id)
         assert local_box_sta == second_word_ann.bounding_box
-        ft_text_ann = first_table_ann.image.get_annotation( # type: ignore
+        ft_text_ann = first_table_ann.image.get_annotation(  # type: ignore
             annotation_ids=second_word_ann.annotation_id
         )[0]
         assert isinstance(ft_text_ann, ImageAnnotation)


### PR DESCRIPTION
In this PR, we 

- rename the environment variables `USE_PILLOW` and `USE_OPENCV`.
- Fix the `viz_handler` method `read_image`, so that 2-dim images can be loaded when using Pillow as image processing library.
- add `accelerate`as additional dependency so that we can train with Transformers trainer. 