### PR TITLE
Add error module and start refactoring exceptions [utils]

### DIFF
--- a/deepdoctection/analyzer/dd.py
+++ b/deepdoctection/analyzer/dd.py
@@ -113,11 +113,12 @@ def config_sanity_checks(cfg: AttrDict) -> None:
     """Some config sanity checks"""
     if cfg.USE_PDF_MINER and cfg.USE_OCR and cfg.OCR.USE_DOCTR:
         raise ValueError("Configuration USE_PDF_MINER= True and USE_OCR=True and USE_DOCTR=True is not allowed")
-    if cfg.OCR.USE_TESSERACT + cfg.OCR.USE_DOCTR + cfg.OCR.USE_TEXTRACT != 1:
-        raise ValueError(
-            "Choose either OCR.USE_TESSERACT=True or OCR.USE_DOCTR=True or OCR.USE_TEXTRACT=True and set the other two "
-            "to False. Only one OCR system can be activated."
-        )
+    if cfg.USE_OCR:
+        if cfg.OCR.USE_TESSERACT + cfg.OCR.USE_DOCTR + cfg.OCR.USE_TEXTRACT != 1:
+            raise ValueError(
+                "Choose either OCR.USE_TESSERACT=True or OCR.USE_DOCTR=True or OCR.USE_TEXTRACT=True "
+                "and set the other two to False. Only one OCR system can be activated."
+            )
 
 
 def build_detector(

--- a/deepdoctection/dataflow/base.py
+++ b/deepdoctection/dataflow/base.py
@@ -17,25 +17,6 @@ from typing import Any, Iterator, no_type_check
 from ..utils.utils import get_rng
 
 
-class DataFlowTerminated(BaseException):
-    """
-    An exception indicating that the DataFlow is unable to produce any more
-    data, i.e. something wrong happened so that calling `__iter__`
-    cannot give a valid iterator anymore.
-    In most DataFlow this will never be raised.
-    """
-
-
-class DataFlowResetStateNotCalled(BaseException):
-    """
-    An exception indicating that `reset_state()` has not been called before starting
-    iteration.
-    """
-
-    def __init__(self) -> None:
-        super().__init__("Iterating a dataflow requires .reset_state() to be called first")
-
-
 class DataFlowReentrantGuard:
     """
     A tool to enforce non-reentrancy.

--- a/deepdoctection/dataflow/custom.py
+++ b/deepdoctection/dataflow/custom.py
@@ -25,10 +25,11 @@ from typing import Any, Callable, Iterable, Iterator, List, Optional
 
 import numpy as np
 
+from ..utils.error import DataFlowResetStateNotCalledError
 from ..utils.logger import LoggingRecord, logger
 from ..utils.tqdm import get_tqdm
 from ..utils.utils import get_rng
-from .base import DataFlow, DataFlowReentrantGuard, DataFlowResetStateNotCalled, ProxyDataFlow
+from .base import DataFlow, DataFlowReentrantGuard, ProxyDataFlow
 from .serialize import DataFromIterable, DataFromList
 
 __all__ = ["CacheData", "CustomDataFromList", "CustomDataFromIterable"]
@@ -65,7 +66,7 @@ class CacheData(ProxyDataFlow):
 
     def __iter__(self) -> Iterator[Any]:
         if self._guard is None:
-            raise DataFlowResetStateNotCalled()
+            raise DataFlowResetStateNotCalledError()
 
         with self._guard:
             if self.buffer:
@@ -139,7 +140,7 @@ class CustomDataFromList(DataFromList):
 
     def __iter__(self) -> Iterator[Any]:
         if self.rng is None:
-            raise DataFlowResetStateNotCalled()
+            raise DataFlowResetStateNotCalledError()
         if self.rebalance_func is not None:
             lst_tmp = self.rebalance_func(self.lst)
             logger.info(LoggingRecord(f"CustomDataFromList: subset size after re-balancing: {len(lst_tmp)}"))

--- a/deepdoctection/dataflow/custom_serialize.py
+++ b/deepdoctection/dataflow/custom_serialize.py
@@ -27,13 +27,16 @@ from pathlib import Path
 from typing import DefaultDict, Dict, List, Optional, Sequence, Union
 
 from jsonlines import Reader, Writer
+from tabulate import tabulate
+from termcolor import colored
 
 from ..utils.context import timed_operation
 from ..utils.detection_types import JsonDict, Pathlike
+from ..utils.error import FileExtensionError
 from ..utils.identifier import get_uuid_from_str
 from ..utils.pdf_utils import PDFStreamer
 from ..utils.tqdm import get_tqdm
-from ..utils.utils import FileExtensionError, is_file_extension
+from ..utils.utils import is_file_extension
 from .base import DataFlow
 from .common import FlattenData, JoinData, MapData
 from .custom import CacheData, CustomDataFromIterable, CustomDataFromList
@@ -223,7 +226,7 @@ class SerializerFiles:
         """
         Not implemented
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 class CocoParser:
@@ -283,8 +286,14 @@ class CocoParser:
         """
         Print information about the annotation file.
         """
+        rows = []
         for key, value in self.dataset["info"].items():
-            print(f"{key}: {value}")
+            row = [key, value]
+            rows.append(row)
+
+        header = ["key", "value"]
+        table = tabulate(rows, headers=header, tablefmt="fancy_grid", stralign="left", numalign="left")
+        print(colored(table, "cyan"))
 
     def get_ann_ids(
         self,
@@ -499,7 +508,7 @@ class SerializerCoco:
         """
         Not implemented
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 class SerializerPdfDoc:
@@ -547,7 +556,7 @@ class SerializerPdfDoc:
         """
         Not implemented
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @staticmethod
     def split(path: Pathlike, path_target: Optional[Pathlike] = None, max_datapoint: Optional[int] = None) -> None:

--- a/deepdoctection/dataflow/serialize.py
+++ b/deepdoctection/dataflow/serialize.py
@@ -16,7 +16,8 @@ from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 
-from .base import DataFlow, DataFlowResetStateNotCalled, RNGDataFlow
+from ..utils.error import DataFlowResetStateNotCalledError
+from .base import DataFlow, RNGDataFlow
 
 
 class DataFromList(RNGDataFlow):
@@ -44,7 +45,7 @@ class DataFromList(RNGDataFlow):
                 for k in idxs:
                     yield self.lst[k]
             else:
-                raise DataFlowResetStateNotCalled()
+                raise DataFlowResetStateNotCalledError()
 
 
 class DataFromIterable(DataFlow):
@@ -63,7 +64,7 @@ class DataFromIterable(DataFlow):
 
     def __len__(self) -> int:
         if self._len is None:
-            raise NotImplementedError
+            raise NotImplementedError()
         return self._len
 
     def __iter__(self) -> Iterator[Any]:
@@ -107,7 +108,7 @@ class FakeData(RNGDataFlow):
 
     def __iter__(self) -> Iterator[Any]:
         if self.rng is None:
-            raise DataFlowResetStateNotCalled()
+            raise DataFlowResetStateNotCalledError()
         if self.random:
             for _ in range(self._size):
                 val = []

--- a/deepdoctection/datapoint/box.py
+++ b/deepdoctection/datapoint/box.py
@@ -28,6 +28,7 @@ import numpy.typing as npt
 from numpy import float32
 
 from ..utils.detection_types import ImageType
+from ..utils.error import BoundingBoxError
 from ..utils.file_utils import cocotools_available
 from ..utils.logger import LoggingRecord, logger
 
@@ -138,10 +139,6 @@ def iou(boxes1: npt.NDArray[float32], boxes2: npt.NDArray[float32]) -> npt.NDArr
     if cocotools_available():
         return coco_iou(boxes1, boxes2)
     return np_iou(boxes1, boxes2)
-
-
-class BoundingBoxError(BaseException):
-    """Special exception only for `BoundingBox`"""
 
 
 @dataclass

--- a/deepdoctection/datapoint/convert.py
+++ b/deepdoctection/datapoint/convert.py
@@ -32,6 +32,7 @@ from pypdf import PdfReader
 
 from ..utils.detection_types import ImageType
 from ..utils.develop import deprecated
+from ..utils.error import DependencyError
 from ..utils.pdf_utils import pdf_to_np_array
 from ..utils.viz import viz_handler
 
@@ -121,7 +122,8 @@ def convert_pdf_bytes_to_np_array(pdf_bytes: bytes, dpi: Optional[int] = None) -
     """
     from pdf2image import convert_from_bytes  # type: ignore # pylint: disable=C0415, E0401
 
-    assert which("pdftoppm") is not None, "convert_pdf_bytes_to_np_array requires poppler to be installed"
+    if which("pdftoppm") is None:
+        raise DependencyError("convert_pdf_bytes_to_np_array requires poppler to be installed")
 
     with BytesIO(pdf_bytes) as pdf_file:
         pdf = PdfReader(pdf_file).pages[0]

--- a/deepdoctection/datasets/adapter.py
+++ b/deepdoctection/datasets/adapter.py
@@ -165,4 +165,4 @@ class DatasetAdapter(IterableDataset):  # type: ignore
         return len(self.df)
 
     def __getitem__(self, item: Any) -> None:
-        raise NotImplementedError
+        raise NotImplementedError()

--- a/deepdoctection/datasets/base.py
+++ b/deepdoctection/datasets/base.py
@@ -51,9 +51,11 @@ class DatasetBase(ABC):
         self._dataflow_builder.splits = self._dataset_info.splits
 
         if not self.dataset_available() and self.is_built_in():
-            print(
-                f"Dataset {self._dataset_info.name} not locally found. Please download at {self._dataset_info.url}"
-                f" and place under {self._dataflow_builder.get_workdir()}"
+            logger.warning(
+                LoggingRecord(
+                    f"Dataset {self._dataset_info.name} not locally found. Please download at {self._dataset_info.url}"
+                    f" and place under {self._dataflow_builder.get_workdir()}"
+                )
             )
 
     @property

--- a/deepdoctection/datasets/dataflow_builder.py
+++ b/deepdoctection/datasets/dataflow_builder.py
@@ -110,7 +110,7 @@ class DataFlowBaseBuilder(ABC):
         :param kwargs: A custom set of arguments/values
         :return: dataflow
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def get_annotation_file(self, split: str) -> str:
         """Get single annotation file."""

--- a/deepdoctection/datasets/info.py
+++ b/deepdoctection/datasets/info.py
@@ -306,7 +306,7 @@ class DatasetCategories:
 
         _cat_to_sub_cat = {get_type(key): get_type(value) for key, value in cat_to_sub_cat.items()}
         if not self._allow_update:
-            raise PermissionError("Replacing categories with sub categories is not allowed")
+            raise RuntimeWarning("Replacing categories with sub categories is not allowed")
         self._categories_update = self.init_categories
         categories = self.get_categories(name_as_key=True)
         cats_or_sub_cats = [
@@ -332,7 +332,7 @@ class DatasetCategories:
         """
 
         if not self._allow_update:
-            raise PermissionError("Filtering categories is not allowed")
+            raise RuntimeWarning("Filtering categories is not allowed")
         if isinstance(categories, (ObjectTypes, str)):
             categories = [get_type(categories)]
         else:

--- a/deepdoctection/datasets/instances/layouttest.py
+++ b/deepdoctection/datasets/instances/layouttest.py
@@ -49,12 +49,7 @@ _LICENSE = (
     " – Permissive – Version 1.0 License. Dr. Janis Meyer does not own the copyright of the images. \n"
     " Use of the images must abide by the PMC Open Access Subset Terms of Use."
 )
-_URL = [
-    "https://www.googleapis.com/drive/v3/files/1ZD4Ef4gd2FIfp7vR8jbnrZeXD3gSWNqE?alt"
-    "=media&key=AIzaSyDuoPG6naK-kRJikScR7cP_1sQBF1r3fWU",
-    "https://www.googleapis.com/drive/v3/files/18HD62LFLa1iAmqffo4SyjuEQ32MzyNQ0?alt"
-    "=media&key=AIzaSyDuoPG6naK-kRJikScR7cP_1sQBF1r3fWU",
-]
+
 _SPLITS: Mapping[str, str] = {"test": "test", "predict": "predict"}
 _TYPE = DatasetType.object_detection
 _LOCATION = "testlayout"
@@ -77,7 +72,7 @@ class LayoutTest(_BuiltInDataset):
 
     @classmethod
     def _info(cls) -> DatasetInfo:
-        return DatasetInfo(name=_NAME, description=_DESCRIPTION, license=_LICENSE, url=_URL, splits=_SPLITS, type=_TYPE)
+        return DatasetInfo(name=_NAME, description=_DESCRIPTION, license=_LICENSE, splits=_SPLITS, type=_TYPE)
 
     def _categories(self) -> DatasetCategories:
         return DatasetCategories(init_categories=_INIT_CATEGORIES)

--- a/deepdoctection/eval/accmetric.py
+++ b/deepdoctection/eval/accmetric.py
@@ -87,7 +87,7 @@ def accuracy(label_gt: Sequence[int], label_predictions: Sequence[int], masks: O
     np_label_gt, np_label_pr = np.asarray(label_gt), np.asarray(label_predictions)
     if len(np_label_gt) != len(np_label_pr):
         raise ValueError(
-            f"length of label_gt ({len(np_label_gt)}) and label_predictions" f" ({len(np_label_pr)}) must be equal"
+            f"length label_gt: {len(np_label_gt)}, length label_predictions: ({len(np_label_pr)}) but must be equal"
         )
     if masks is not None:
         np_label_gt, np_label_pr = _mask_some_gt_and_pr_labels(np_label_gt, np_label_pr, masks)

--- a/deepdoctection/eval/base.py
+++ b/deepdoctection/eval/base.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, List, Optional, Tuple
 from ..dataflow import DataFlow
 from ..datasets.info import DatasetCategories
 from ..utils.detection_types import JsonDict
+from ..utils.error import DependencyError
 from ..utils.file_utils import Requirement
 
 
@@ -52,7 +53,7 @@ class MetricBase(ABC):
         requirements = cls.get_requirements()
         name = cls.__name__ if hasattr(cls, "__name__") else cls.__class__.__name__
         if not all(requirement[1] for requirement in requirements):
-            raise ImportError(
+            raise DependencyError(
                 "\n".join(
                     [f"{name} has the following dependencies:"]
                     + [requirement[2] for requirement in requirements if not requirement[1]]
@@ -66,7 +67,7 @@ class MetricBase(ABC):
         """
         Get a list of requirements for running the detector
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @classmethod
     @abstractmethod
@@ -80,7 +81,7 @@ class MetricBase(ABC):
         :param dataflow_predictions: Dataflow with predictions.
         :param categories:  DatasetCategories with respect to the underlying dataset.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @classmethod
     @abstractmethod
@@ -95,7 +96,7 @@ class MetricBase(ABC):
         :param dataflow_predictions: Dataflow with predictions.
         :param categories: DatasetCategories with respect to the underlying dataset.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @classmethod
     def result_list_to_dict(cls, results: List[JsonDict]) -> JsonDict:

--- a/deepdoctection/eval/eval.py
+++ b/deepdoctection/eval/eval.py
@@ -171,7 +171,7 @@ class Evaluator:
                         "metric has no attribute sub_cats and cannot be used for token classification datasets"
                     )
             else:
-                raise NotImplementedError
+                raise NotImplementedError()
 
         else:
             self.wandb_table_agent = None
@@ -271,7 +271,7 @@ class Evaluator:
             sub_cats_to_remove = meta_anns["sub_categories"]
             df_pr = MapData(df_pr, remove_cats(sub_categories=sub_cats_to_remove))
         else:
-            raise NotImplementedError
+            raise NotImplementedError()
 
         return df_pr
 

--- a/deepdoctection/eval/tp_eval_callback.py
+++ b/deepdoctection/eval/tp_eval_callback.py
@@ -83,10 +83,11 @@ class EvalCallback(Callback):  # pylint: disable=R0903
         self.num_gpu = get_num_gpu()
         self.category_names = category_names
         self.sub_categories = sub_categories
-        assert isinstance(pipeline_component.predictor, TPFrcnnDetector), (
-            f"pipeline_component.predictor must be of "
-            f"type TPFrcnnDetector but is type {type(pipeline_component.predictor)}"
-        )
+        if not isinstance(pipeline_component.predictor, TPFrcnnDetector):
+            raise TypeError(
+                f"pipeline_component.predictor must be of type TPFrcnnDetector but is "
+                f"type {type(pipeline_component.predictor)}"
+            )
         self.cfg = pipeline_component.predictor.model.cfg
         if _use_replicated(self.cfg):
             self.evaluator = Evaluator(dataset, pipeline_component, metric, num_threads=self.num_gpu * 2)

--- a/deepdoctection/extern/pt/ptutils.py
+++ b/deepdoctection/extern/pt/ptutils.py
@@ -20,6 +20,7 @@ Torch related utils
 """
 
 
+from ...utils.error import DependencyError
 from ...utils.file_utils import pytorch_available
 
 
@@ -31,7 +32,7 @@ def set_torch_auto_device() -> "torch.device":  # type: ignore
         from torch import cuda, device  # pylint: disable=C0415
 
         return device("cuda" if cuda.is_available() else "cpu")
-    raise ModuleNotFoundError("Pytorch must be installed")
+    raise DependencyError("Pytorch must be installed")
 
 
 def get_num_gpu() -> int:
@@ -45,4 +46,4 @@ def get_num_gpu() -> int:
         from torch import cuda  # pylint: disable=C0415
 
         return cuda.device_count()
-    raise ModuleNotFoundError("Pytorch must be installed")
+    raise DependencyError("Pytorch must be installed")

--- a/deepdoctection/extern/tessocr.py
+++ b/deepdoctection/extern/tessocr.py
@@ -30,7 +30,8 @@ import numpy as np
 
 from ..utils.context import save_tmp_file, timeout_manager
 from ..utils.detection_types import ImageType, Requirement
-from ..utils.file_utils import _TESS_PATH, TesseractNotFound, get_tesseract_requirement
+from ..utils.error import DependencyError, TesseractError
+from ..utils.file_utils import _TESS_PATH, get_tesseract_requirement
 from ..utils.metacfg import config_to_cli_str, set_config_by_yaml
 from ..utils.settings import LayoutType, ObjectTypes
 from .base import DetectionResult, ObjectDetector, PredictorBase
@@ -55,18 +56,6 @@ _LANG_CODE_TO_TESS_LANG_CODE = {
     "alb": "nor",
     "nn": "eng",
 }
-
-
-class TesseractError(RuntimeError):
-    """
-    Tesseract Error
-    """
-
-    def __init__(self, status: int, message: str) -> None:
-        super().__init__()
-        self.status = status
-        self.message = message
-        self.args = (status, message)
 
 
 def _subprocess_args() -> Dict[str, Any]:
@@ -109,7 +98,7 @@ def _run_tesseract(tesseract_args: List[str]) -> None:
     except OSError as error:
         if error.errno != ENOENT:
             raise error from error
-        raise TesseractNotFound("Tesseract not found. Please install or add to your PATH.") from error
+        raise DependencyError("Tesseract not found. Please install or add to your PATH.") from error
 
     with timeout_manager(proc, 0) as error_string:
         if proc.returncode:

--- a/deepdoctection/extern/tp/tpcompat.py
+++ b/deepdoctection/extern/tp/tpcompat.py
@@ -55,7 +55,7 @@ class ModelDescWithConfig(ModelDesc, ABC):  # type: ignore
 
         :return: Tuple of list input and list output names. The names must coincide with tensor within the model.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 class TensorpackPredictor(ABC):
@@ -113,7 +113,7 @@ class TensorpackPredictor(ABC):
         Implement the config generation, its modification and instantiate a version of the model. See
         `pipe.tpfrcnn.TPFrcnnDetector` for an example
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @abstractmethod
     def predict(self, np_img: Any) -> Any:
@@ -121,7 +121,7 @@ class TensorpackPredictor(ABC):
         Implement, how `self.tp_predictor` is invoked and raw prediction results are generated. Do use only raw
         objects and nothing, which is related to the DD API.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property
     def model(self) -> ModelDescWithConfig:

--- a/deepdoctection/extern/tp/tpfrcnn/preproc.py
+++ b/deepdoctection/extern/tp/tpfrcnn/preproc.py
@@ -18,6 +18,7 @@ from tensorpack.dataflow.imgaug import AugmentorList, ImageAugmentor
 
 from ....datapoint.convert import box_to_point4, point4_to_box
 from ....utils.detection_types import ImageType, JsonDict
+from ....utils.error import MalformedData
 from ....utils.logger import log_once
 from .common import filter_boxes_inside_shape, np_iou
 from .modeling.model_fpn import get_all_anchors_fpn
@@ -25,12 +26,6 @@ from .utils.np_box_ops import area as np_area
 from .utils.np_box_ops import ioa as np_ioa
 
 # pylint: enable=import-error
-
-
-class MalformedData(BaseException):
-    """
-    Exception class for malformed data
-    """
 
 
 def augment(dp: JsonDict, imgaug_list: List[ImageAugmentor], add_mask: bool) -> JsonDict:
@@ -62,7 +57,7 @@ def augment(dp: JsonDict, imgaug_list: List[ImageAugmentor], add_mask: bool) -> 
         assert np.min(np_area(gt_boxes)) > 0, "some boxes have zero area"
 
     if add_mask:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     return dp
 

--- a/deepdoctection/mapper/d2struct.py
+++ b/deepdoctection/mapper/d2struct.py
@@ -93,7 +93,7 @@ def image_to_d2_frcnn_training(
         annotations.append(mapped_ann)
 
         if add_mask:
-            raise NotImplementedError
+            raise NotImplementedError("Segmentation in deepdoctection is not supported")
 
     output["annotations"] = annotations
 

--- a/deepdoctection/mapper/hfstruct.py
+++ b/deepdoctection/mapper/hfstruct.py
@@ -81,7 +81,7 @@ def image_to_hf_detr_training(
         annotations.append(mapped_ann)
 
     if add_mask:
-        raise NotImplementedError
+        raise NotImplementedError("Segmentation in deepdoctection is not supported")
 
     output["annotations"] = annotations
 

--- a/deepdoctection/mapper/laylmstruct.py
+++ b/deepdoctection/mapper/laylmstruct.py
@@ -146,7 +146,7 @@ def image_to_raw_layoutlm_features(
             raise TypeError(f"char_cat must be of type ContainerAnnotation but is of type {type(char_cat)}")
         word = char_cat.value
         if not isinstance(word, str):
-            raise ValueError(f"word must be of type str but is of type {type(word)}")
+            raise TypeError(f"word must be of type str but is of type {type(word)}")
         all_words.append(word)
 
         box = ann.get_bounding_box(dp.image_id)

--- a/deepdoctection/mapper/maputils.py
+++ b/deepdoctection/mapper/maputils.py
@@ -28,8 +28,8 @@ import numpy as np
 from tabulate import tabulate
 from termcolor import colored
 
-from ..datapoint.box import BoundingBoxError
 from ..utils.detection_types import DP, BaseExceptionType, S, T
+from ..utils.error import AnnotationError, BoundingBoxError, ImageError, UUIDError
 from ..utils.logger import LoggingRecord, logger
 from ..utils.settings import ObjectTypes
 
@@ -72,7 +72,18 @@ class MappingContextManager:
         """
         if (
             exc_type
-            in (KeyError, ValueError, IndexError, AssertionError, TypeError, BoundingBoxError, FileNotFoundError)
+            in (
+                KeyError,
+                ValueError,
+                IndexError,
+                AssertionError,
+                TypeError,
+                FileNotFoundError,
+                BoundingBoxError,
+                AnnotationError,
+                ImageError,
+                UUIDError,
+            )
             and exc_tb is not None
         ):
             frame_summary = traceback.extract_tb(exc_tb)[0]

--- a/deepdoctection/mapper/prodigystruct.py
+++ b/deepdoctection/mapper/prodigystruct.py
@@ -128,7 +128,7 @@ def prodigy_to_image(
             else:
                 label = span["label"]
             if not isinstance(label, str):
-                raise ValueError("label could not assigned to be a string")
+                raise TypeError("label must be a string")
 
             annotation = ImageAnnotation(
                 category_name=label,

--- a/deepdoctection/mapper/pubstruct.py
+++ b/deepdoctection/mapper/pubstruct.py
@@ -75,12 +75,14 @@ def _cell_token(html: Sequence[str]) -> List[List[int]]:
 def _item_spans(html: Sequence[str], index_cells: Sequence[Sequence[int]], item: str) -> List[List[int]]:
     item_spans = [
         [
-            int(html[index_cell - 1].replace(item + "=", "").replace('"', ""))
-            if (item in html[index_cell - 1] and html[index_cell] == ">")
-            else (
-                int(html[index_cell - 2].replace(item + "=", "").replace('"', ""))
-                if (item in html[index_cell - 2] and html[index_cell] == ">")
-                else 1
+            (
+                int(html[index_cell - 1].replace(item + "=", "").replace('"', ""))
+                if (item in html[index_cell - 1] and html[index_cell] == ">")
+                else (
+                    int(html[index_cell - 2].replace(item + "=", "").replace('"', ""))
+                    if (item in html[index_cell - 2] and html[index_cell] == ">")
+                    else 1
+                )
             )
             for index_cell in index_cell_per_row
         ]
@@ -210,9 +212,7 @@ def _add_items(image: Image, item_type: str, categories_name_as_key: Dict[str, s
         items = image.get_annotation(category_names=TableType.item)
         item_type_anns = [ann for ann in items if ann.get_sub_category(TableType.item).category_name == item_type]
         item_type_anns.sort(
-            key=lambda x: x.bounding_box.cx  # type: ignore
-            if item_type == LayoutType.column
-            else x.bounding_box.cy  # type: ignore
+            key=lambda x: (x.bounding_box.cx if item_type == LayoutType.column else x.bounding_box.cy)  # type: ignore
         )
         if table.bounding_box:
             tmp_item_xy = table.bounding_box.uly + 1.0 if item_type == LayoutType.row else table.bounding_box.ulx + 1.0
@@ -389,7 +389,7 @@ def pub_to_image_uncur(  # pylint: disable=R0914
     with MappingContextManager(str(idx)) as mapping_context:
         max_rs, max_cs = 0, 0
         if idx is None:
-            raise ValueError("No valid datapoint external id")
+            raise TypeError("imgid is None but must be a string")
 
         image = Image(file_name=os.path.split(dp["filename"])[1], location=dp["filename"], external_id=idx)
 

--- a/deepdoctection/mapper/tpstruct.py
+++ b/deepdoctection/mapper/tpstruct.py
@@ -67,7 +67,7 @@ def image_to_tp_frcnn_training(
         all_categories.append(ann.category_id)
 
         if add_mask:
-            raise NotImplementedError
+            raise NotImplementedError()
 
     output["gt_boxes"] = np.asarray(all_boxes, dtype="float32")
     output["gt_labels"] = np.asarray(all_categories, dtype="int32")

--- a/deepdoctection/pipe/base.py
+++ b/deepdoctection/pipe/base.py
@@ -75,7 +75,7 @@ class PipelineComponent(ABC):
         As a simplified interface `serve` does not have to return a dp. The data point is passed on within
         pipelines internally (via `pass_datapoint`).
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def pass_datapoint(self, dp: Image) -> Image:
         """
@@ -109,7 +109,7 @@ class PipelineComponent(ABC):
         """
         Clone an instance
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @abstractmethod
     def get_meta_annotation(self) -> JsonDict:
@@ -122,7 +122,7 @@ class PipelineComponent(ABC):
         `summaries` with values: A list of summary sub categories
         :return: Dict with meta infos as just described
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _meta_has_all_types(self) -> None:
         if not {"image_annotations", "sub_categories", "relationships", "summaries"}.issubset(
@@ -154,7 +154,7 @@ class PredictorPipelineComponent(PipelineComponent, ABC):
 
     @abstractmethod
     def clone(self) -> "PredictorPipelineComponent":
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 class LanguageModelPipelineComponent(PipelineComponent, ABC):
@@ -183,7 +183,7 @@ class LanguageModelPipelineComponent(PipelineComponent, ABC):
         """
         Clone an instance
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 class ImageTransformPipelineComponent(PipelineComponent, ABC):
@@ -206,7 +206,7 @@ class ImageTransformPipelineComponent(PipelineComponent, ABC):
         """
         Clone an instance
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 class Pipeline(ABC):
@@ -254,7 +254,7 @@ class Pipeline(ABC):
 
         :param kwargs: Arguments, for dynamic customizing of the processing or for the transfer of processing types
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _build_pipe(self, df: DataFlow) -> DataFlow:
         """
@@ -277,7 +277,7 @@ class Pipeline(ABC):
 
         can be triggered.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def get_meta_annotation(self) -> JsonDict:
         """

--- a/deepdoctection/pipe/doctectionpipe.py
+++ b/deepdoctection/pipe/doctectionpipe.py
@@ -82,7 +82,6 @@ def _proto_process(
     else:
         path_tmp = path
     logger.info(LoggingRecord(f"Processing {file_name}", {"path": path_tmp, "df": path_tmp, "file_name": file_name}))
-    # logger.info("Processing %s", file_name, {"path": path_tmp, "df": path_tmp, "file_name": file_name})
     return dp
 
 

--- a/deepdoctection/pipe/language.py
+++ b/deepdoctection/pipe/language.py
@@ -25,6 +25,7 @@ from ..datapoint.image import Image
 from ..datapoint.view import Page
 from ..extern.base import LanguageDetector, ObjectDetector
 from ..utils.detection_types import JsonDict
+from ..utils.error import ImageError
 from ..utils.settings import PageType, TypeOrStr, get_type
 from .base import PipelineComponent
 from .registry import pipeline_component_registry
@@ -86,7 +87,7 @@ class LanguageDetectionService(PipelineComponent):
             text = page.text_no_line_break
         else:
             if dp.image is None:
-                raise ValueError("dp.image cannot be None")
+                raise ImageError("image cannot be None")
             detect_result_list = self.text_detector.predict(dp.image)
             # this is a concatenation of all detection result. No reading order
             text = " ".join([result.text for result in detect_result_list if result.text is not None])
@@ -98,7 +99,7 @@ class LanguageDetectionService(PipelineComponent):
     def clone(self) -> PipelineComponent:
         predictor = self.predictor.clone()
         if not isinstance(predictor, LanguageDetector):
-            raise ValueError(f"Predictor must be of type LanguageDetector, but is of type {type(predictor)}")
+            raise TypeError(f"Predictor must be of type LanguageDetector, but is of type {type(predictor)}")
         return self.__class__(
             predictor,
             copy(self.text_container),

--- a/deepdoctection/pipe/layout.py
+++ b/deepdoctection/pipe/layout.py
@@ -25,6 +25,7 @@ import numpy as np
 from ..datapoint.image import Image
 from ..extern.base import ObjectDetector, PdfMiner
 from ..utils.detection_types import JsonDict
+from ..utils.error import ImageError
 from ..utils.transform import PadTransform
 from .base import PredictorPipelineComponent
 from .registry import pipeline_component_registry
@@ -79,7 +80,7 @@ class ImageLayoutService(PredictorPipelineComponent):
             if anns:
                 return
         if dp.image is None:
-            raise ValueError("image cannot be None")
+            raise ImageError("image cannot be None")
         np_image = dp.image
         if self.padder:
             np_image = self.padder.apply_image(np_image)
@@ -114,5 +115,5 @@ class ImageLayoutService(PredictorPipelineComponent):
         if self.padder:
             padder_clone = self.padder.clone()
         if not isinstance(predictor, ObjectDetector):
-            raise ValueError(f"predictor must be of type ObjectDetector, but is of type {type(predictor)}")
+            raise TypeError(f"predictor must be of type ObjectDetector, but is of type {type(predictor)}")
         return self.__class__(predictor, self.to_image, self.crop_image, padder_clone, self.skip_if_layout_extracted)

--- a/deepdoctection/pipe/lm.py
+++ b/deepdoctection/pipe/lm.py
@@ -252,7 +252,7 @@ class LMTokenClassifierService(LanguageModelPipelineComponent):
             self.language_model.model.__class__.__name__, use_xlm_tokenizer
         )
         if not isinstance(self.tokenizer, type(tokenizer_reference)):
-            raise ValueError(
+            raise TypeError(
                 f"You want to use {type(self.tokenizer)} but you should use {type(tokenizer_reference)} "
                 f"in this framework"
             )
@@ -366,7 +366,7 @@ class LMSequenceClassifierService(LanguageModelPipelineComponent):
             self.language_model.model.__class__.__name__, use_xlm_tokenizer
         )
         if not isinstance(self.tokenizer, type(tokenizer_reference)):
-            raise ValueError(
+            raise TypeError(
                 f"You want to use {type(self.tokenizer)} but you should use {type(tokenizer_reference)} "
                 f"in this framework"
             )

--- a/deepdoctection/pipe/refine.py
+++ b/deepdoctection/pipe/refine.py
@@ -33,6 +33,7 @@ from ..datapoint.image import Image
 from ..extern.base import DetectionResult
 from ..mapper.maputils import MappingContextManager
 from ..utils.detection_types import JsonDict
+from ..utils.error import ImageError
 from ..utils.settings import CellType, LayoutType, Relationships, TableType, get_type
 from .base import PipelineComponent
 from .registry import pipeline_component_registry
@@ -302,7 +303,7 @@ def generate_html_string(table: ImageAnnotation) -> List[str]:
     :return: HTML representation of the table
     """
     if table.image is None:
-        raise ValueError("table.image cannot be None")
+        raise ImageError("table.image cannot be None")
     table_image = table.image
     cells = table_image.get_annotation(
         category_names=[
@@ -412,7 +413,7 @@ class TableSegmentationRefinementService(PipelineComponent):
         tables = dp.get_annotation(category_names=self._table_name)
         for table in tables:
             if table.image is None:
-                raise ValueError("table.image cannot be None")
+                raise ImageError("table.image cannot be None")
             tiles_to_cells_list = tiles_to_cells(dp, table)
             connected_components, tile_to_cell_dict = connected_component_tiles(tiles_to_cells_list)
             rectangle_tiling = generate_rectangle_tiling(connected_components)

--- a/deepdoctection/pipe/text.py
+++ b/deepdoctection/pipe/text.py
@@ -26,6 +26,7 @@ from ..datapoint.image import Image
 from ..extern.base import ObjectDetector, PdfMiner, TextRecognizer
 from ..extern.tessocr import TesseractOcrDetector
 from ..utils.detection_types import ImageType, JsonDict
+from ..utils.error import ImageError
 from ..utils.settings import PageType, TypeOrStr, WordType, get_type
 from .base import PredictorPipelineComponent
 from .registry import pipeline_component_registry
@@ -89,7 +90,10 @@ class TextExtractionService(PredictorPipelineComponent):
         super().__init__(self._get_name(text_extract_detector.name), text_extract_detector)
         if self.extract_from_category:
             if not isinstance(self.predictor, (ObjectDetector, TextRecognizer)):
-                raise TypeError("Predicting from a cropped image requires to pass an ObjectDetector or TextRecognizer.")
+                raise TypeError(
+                    f"Predicting from a cropped image requires to pass an ObjectDetector or "
+                    f"TextRecognizer. Got {type(self.predictor)}"
+                )
         if run_time_ocr_language_selection:
             assert isinstance(
                 self.predictor, TesseractOcrDetector
@@ -171,13 +175,13 @@ class TextExtractionService(PredictorPipelineComponent):
 
         if isinstance(text_roi, ImageAnnotation):
             if text_roi.image is None:
-                raise ValueError("text_roi.image cannot be None")
+                raise ImageError("text_roi.image cannot be None")
             if text_roi.image.image is None:
-                raise ValueError("text_roi.image.image cannot be None")
+                raise ImageError("text_roi.image.image cannot be None")
             return text_roi.image.image
         if isinstance(self.predictor, ObjectDetector):
             if not isinstance(text_roi, Image):
-                raise ValueError("text_roi must be an image")
+                raise ImageError("text_roi must be an image")
             return text_roi.image
         if isinstance(text_roi, list):
             assert all(roi.image is not None for roi in text_roi)
@@ -201,9 +205,11 @@ class TextExtractionService(PredictorPipelineComponent):
             [
                 (
                     "image_annotations",
-                    self.predictor.possible_categories()
-                    if isinstance(self.predictor, (ObjectDetector, PdfMiner))
-                    else [],
+                    (
+                        self.predictor.possible_categories()
+                        if isinstance(self.predictor, (ObjectDetector, PdfMiner))
+                        else []
+                    ),
                 ),
                 ("sub_categories", sub_cat_dict),
                 ("relationships", {}),
@@ -218,5 +224,5 @@ class TextExtractionService(PredictorPipelineComponent):
     def clone(self) -> "PredictorPipelineComponent":
         predictor = self.predictor.clone()
         if not isinstance(predictor, (ObjectDetector, PdfMiner, TextRecognizer)):
-            raise ValueError(f"predictor must be of type ObjectDetector or PdfMiner, but is of type {type(predictor)}")
+            raise ImageError(f"predictor must be of type ObjectDetector or PdfMiner, but is of type {type(predictor)}")
         return self.__class__(predictor, deepcopy(self.extract_from_category), self.run_time_ocr_language_selection)

--- a/deepdoctection/train/hf_detr_train.py
+++ b/deepdoctection/train/hf_detr_train.py
@@ -97,9 +97,9 @@ class DetrDerivedTrainer(Trainer):
 
     def evaluate(
         self,
-        eval_dataset: Optional[Dataset[Any]] = None,
-        ignore_keys: Optional[List[str]] = None,
-        metric_key_prefix: str = "eval",
+        eval_dataset: Optional[Dataset[Any]] = None,  # pylint: disable=W0613
+        ignore_keys: Optional[List[str]] = None,  # pylint: disable=W0613
+        metric_key_prefix: str = "eval",  # pylint: disable=W0613
     ) -> Dict[str, float]:
         """
         Overwritten method from `Trainer`. Arguments will not be used.
@@ -193,9 +193,11 @@ def train_hf_detr(
         "remove_unused_columns": False,
         "per_device_train_batch_size": 2,
         "max_steps": number_samples,
-        "evaluation_strategy": "steps"
-        if (dataset_val is not None and metric is not None and pipeline_component_name is not None)
-        else "no",
+        "evaluation_strategy": (
+            "steps"
+            if (dataset_val is not None and metric is not None and pipeline_component_name is not None)
+            else "no"
+        ),
         "eval_steps": 5000,
     }
 

--- a/deepdoctection/utils/__init__.py
+++ b/deepdoctection/utils/__init__.py
@@ -6,7 +6,10 @@ Init file for utils package
 """
 from typing import Optional, Tuple, Union, no_type_check
 
+from .concurrency import *
 from .context import *
+from .env_info import *
+from .error import *
 from .file_utils import *
 from .fs import *
 from .identifier import *

--- a/deepdoctection/utils/context.py
+++ b/deepdoctection/utils/context.py
@@ -61,7 +61,7 @@ def timeout_manager(proc, seconds: Optional[int] = None) -> Iterator[str]:  # ty
             proc.terminate()
             proc.kill()
             proc.returncode = -1
-            raise RuntimeError("Tesseract process timeout")  # pylint: disable=W0707
+            raise RuntimeError(f"timeout for process id: {proc.pid}")  # pylint: disable=W0707
     finally:
         if proc.stdin is not None:
             proc.stdin.close()

--- a/deepdoctection/utils/env_info.py
+++ b/deepdoctection/utils/env_info.py
@@ -520,7 +520,7 @@ def get_device(ignore_cpu: bool = True) -> str:
         return "mps"
     if not ignore_cpu:
         return "cpu"
-    raise ValueError("Could not find either GPU nor MPS")
+    raise RuntimeWarning("Could not find either GPU nor MPS")
 
 
 def auto_select_viz_library() -> None:

--- a/deepdoctection/utils/error.py
+++ b/deepdoctection/utils/error.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# File: error.py
+
+# Copyright 2024 Dr. Janis Meyer. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module for custom exceptions
+"""
+
+
+class BoundingBoxError(BaseException):
+    """Special exception only for `datapoint.box.BoundingBox`"""
+
+
+class AnnotationError(BaseException):
+    """Special exception only for `datapoint.annotation.Annotation`"""
+
+
+class ImageError(BaseException):
+    """Special exception only for `datapoint.image.Image`"""
+
+
+class UUIDError(BaseException):
+    """Special exception only for `utils.identifier`"""
+
+
+class DependencyError(BaseException):
+    """Special exception only for missing dependencies. We do not use the internals ImportError or
+    ModuleNotFoundError."""
+
+
+class DataFlowTerminatedError(BaseException):
+    """
+    An exception indicating that the DataFlow is unable to produce any more
+    data, i.e. something wrong happened so that calling `__iter__`
+    cannot give a valid iterator anymore.
+    In most DataFlow this will never be raised.
+    """
+
+
+class DataFlowResetStateNotCalledError(BaseException):
+    """
+    An exception indicating that `reset_state()` has not been called before starting
+    iteration.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Iterating a dataflow requires .reset_state() to be called first")
+
+
+class MalformedData(BaseException):
+    """
+    Exception class for malformed data. Use this class if something does not look right with the data
+    """
+
+
+class FileExtensionError(BaseException):
+    """
+    Exception class for wrong file extensions.
+    """
+
+
+class TesseractError(RuntimeError):
+    """
+    Tesseract Error
+    """
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__()
+        self.status = status
+        self.message = message
+        self.args = (status, message)

--- a/deepdoctection/utils/file_utils.py
+++ b/deepdoctection/utils/file_utils.py
@@ -22,6 +22,7 @@ import importlib_metadata
 from packaging import version
 
 from .detection_types import Requirement
+from .error import DependencyError
 from .logger import LoggingRecord, logger
 from .metacfg import AttrDict
 
@@ -263,7 +264,7 @@ def set_tesseract_path(tesseract_path: str) -> None:
     :param tesseract_path: Tesseract installation path.
     """
     if tesseract_path is None:
-        raise ValueError("tesseract_path is empty.")
+        raise TypeError("tesseract_path cannot be None")
 
     global _TESS_AVAILABLE  # pylint: disable=W0603
     global _TESS_PATH  # pylint: disable=W0603
@@ -288,12 +289,6 @@ def tesseract_available() -> bool:
 # copy paste from https://github.com/madmaze/pytesseract/blob/master/pytesseract/pytesseract.py
 
 
-class TesseractNotFound(BaseException):
-    """
-    Exception class for Tesseract being not found
-    """
-
-
 def get_tesseract_version() -> Union[int, version.Version]:
     """
     Returns Version object of the Tesseract version. We need at least Tesseract 3.05
@@ -306,7 +301,7 @@ def get_tesseract_version() -> Union[int, version.Version]:
             stdin=subprocess.DEVNULL,
         )
     except OSError:
-        raise TesseractNotFound(_TESS_ERR_MSG) from OSError
+        raise DependencyError(_TESS_ERR_MSG) from OSError
 
     raw_version = output.decode("utf-8")
     str_version, *_ = raw_version.lstrip(string.printable[10:]).partition(" ")
@@ -348,12 +343,6 @@ def pdf_to_cairo_available() -> bool:
     return bool(_PDF_TO_CAIRO_AVAILABLE)
 
 
-class PopplerNotFound(BaseException):
-    """
-    Exception class for Poppler being not found
-    """
-
-
 def get_poppler_version() -> Union[int, version.Version]:
     """
     Returns Version object of the Poppler version. We need at least Tesseract 3.05
@@ -371,7 +360,7 @@ def get_poppler_version() -> Union[int, version.Version]:
             [command, "-v"], stderr=subprocess.STDOUT, env=environ, stdin=subprocess.DEVNULL
         )
     except OSError:
-        raise PopplerNotFound() from OSError
+        raise DependencyError(_POPPLER_ERR_MSG) from OSError
 
     raw_version = output.decode("utf-8")
     list_version = raw_version.split("\n", maxsplit=1)[0].split(" ")[-1].split(".")

--- a/deepdoctection/utils/fs.py
+++ b/deepdoctection/utils/fs.py
@@ -34,7 +34,7 @@ from .logger import LoggingRecord, logger
 from .pdf_utils import get_pdf_file_reader, get_pdf_file_writer
 from .settings import CONFIGS, DATASET_DIR, MODEL_DIR, PATH
 from .tqdm import get_tqdm
-from .utils import FileExtensionError, is_file_extension
+from .utils import is_file_extension
 from .viz import viz_handler
 
 __all__ = [
@@ -44,9 +44,7 @@ __all__ = [
     "maybe_path_or_pdf",
     "download",
     "mkdir_p",
-    "is_file_extension",
     "load_json",
-    "FileExtensionError",
     "sub_path",
     "get_package_path",
     "get_configs_dir_path",
@@ -125,8 +123,8 @@ def download(url: str, directory: Pathlike, file_name: Optional[str] = None, exp
     assert size > 0, f"Downloaded an empty file from {url}!"
 
     if expect_size is not None and size != expect_size:
-        logger.error(LoggingRecord(f"File downloaded from {url} does not match the expected size!"))
-        logger.error(
+        logger.warning(LoggingRecord(f"File downloaded from {url} does not match the expected size!"))
+        logger.warning(
             LoggingRecord("You may have downloaded a broken file, or the upstream may have modified the file.")
         )
 
@@ -210,13 +208,15 @@ def get_load_image_func(
     :return: The function loading the file (and converting to its desired format)
     """
 
-    assert is_file_extension(path, [".png", ".jpeg", ".jpg", ".pdf", ".tif"]), f"image type not allowed: {path}"
+    assert is_file_extension(path, [".png", ".jpeg", ".jpg", ".pdf", ".tif"]), f"image type not allowed: " f"{path}"
 
     if is_file_extension(path, [".png", ".jpeg", ".jpg", ".tif"]):
         return load_image_from_file
     if is_file_extension(path, [".pdf"]):
         return load_bytes_from_pdf_file
-    return NotImplemented
+    raise NotImplementedError(
+        "File extension not supported by any loader. Please specify a file type and raise an issue"
+    )
 
 
 def maybe_path_or_pdf(path: Pathlike) -> int:

--- a/deepdoctection/utils/pdf_utils.py
+++ b/deepdoctection/utils/pdf_utils.py
@@ -32,9 +32,10 @@ from pypdf import PdfReader, PdfWriter, errors
 
 from .context import save_tmp_file, timeout_manager
 from .detection_types import ImageType, Pathlike
-from .file_utils import PopplerNotFound, pdf_to_cairo_available, pdf_to_ppm_available, qpdf_available
+from .error import DependencyError, FileExtensionError
+from .file_utils import pdf_to_cairo_available, pdf_to_ppm_available, qpdf_available
 from .logger import LoggingRecord, logger
-from .utils import FileExtensionError, is_file_extension
+from .utils import is_file_extension
 from .viz import viz_handler
 
 __all__ = ["decrypt_pdf_document", "get_pdf_file_reader", "get_pdf_file_writer", "PDFStreamer", "pdf_to_np_array"]
@@ -165,7 +166,7 @@ def _input_to_cli_str(
     elif pdf_to_cairo_available():
         command = "pdftocairo"
     else:
-        raise PopplerNotFound("Poppler not found. Please install or add to your PATH.")
+        raise DependencyError("Poppler not found. Please install or add to your PATH.")
 
     if platform.system() == "Windows":
         command = command + ".exe"
@@ -201,7 +202,7 @@ def _run_poppler(poppler_args: List[str]) -> None:
     except OSError as error:
         if error.errno != ENOENT:
             raise error from error
-        raise PopplerNotFound("Poppler not found. Please install or add to your PATH.") from error
+        raise DependencyError("Poppler not found. Please install or add to your PATH.") from error
 
     with timeout_manager(proc, 0):
         if proc.returncode:

--- a/deepdoctection/utils/settings.py
+++ b/deepdoctection/utils/settings.py
@@ -324,7 +324,9 @@ def token_class_tag_to_token_class_with_tag(token: ObjectTypes, tag: ObjectTypes
     """
     if isinstance(token, TokenClasses) and isinstance(tag, BioTag):
         return _TOKEN_AND_TAG_TO_TOKEN_CLASS_WITH_TAG[(token, tag)]
-    raise TypeError("Token must be of type TokenClasses and tag must be of type BioTag")
+    raise TypeError(
+        f"Token must be of type TokenClasses, is of {type(token)} and tag " f"{type(tag)} must be of type BioTag"
+    )
 
 
 def token_class_with_tag_to_token_class_and_tag(

--- a/deepdoctection/utils/transform.py
+++ b/deepdoctection/utils/transform.py
@@ -47,7 +47,7 @@ class BaseTransform(ABC):
     @abstractmethod
     def apply_image(self, img: ImageType) -> ImageType:
         """The transformation that should be applied to the image"""
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 class ResizeTransform(BaseTransform):

--- a/deepdoctection/utils/utils.py
+++ b/deepdoctection/utils/utils.py
@@ -144,12 +144,6 @@ def get_rng(obj: Any = None) -> np.random.RandomState:
     return np.random.RandomState(seed)
 
 
-class FileExtensionError(BaseException):
-    """
-    An exception indicating that a file does not seem to have an expected type
-    """
-
-
 def is_file_extension(file_name: Pathlike, extension: Union[str, Sequence[str]]) -> bool:
     """
     Check if a given file name has a given extension

--- a/deepdoctection/utils/viz.py
+++ b/deepdoctection/utils/viz.py
@@ -38,6 +38,7 @@ from numpy import float32, uint8
 
 from .detection_types import ImageType
 from .env_info import auto_select_viz_library
+from .error import DependencyError
 from .file_utils import get_opencv_requirement, get_pillow_requirement, opencv_available, pillow_available
 
 if opencv_available():
@@ -352,12 +353,12 @@ class VizPackageHandler:
         if maybe_cv2:
             requirements = get_opencv_requirement()
             if not requirements[1]:
-                raise ImportError(requirements[2])
+                raise DependencyError(requirements[2])
             return maybe_cv2
 
         requirements = get_pillow_requirement()
         if not requirements[1]:
-            raise ImportError(requirements[2])
+            raise DependencyError(requirements[2])
         return "pillow"
 
     def _set_vars(self, package: str) -> None:

--- a/tests/datapoint/test_image.py
+++ b/tests/datapoint/test_image.py
@@ -28,6 +28,7 @@ from pytest import mark, raises
 from deepdoctection.dataflow import DataFlow, MapData, SerializerJsonlines
 from deepdoctection.datapoint import BoundingBox, CategoryAnnotation, Image, ImageAnnotation
 from deepdoctection.utils import get_uuid
+from deepdoctection.utils.error import ImageError
 from deepdoctection.utils.settings import get_type
 
 from ..test_utils import anns_to_ids, collect_datapoint_from_dataflow, get_test_path
@@ -82,7 +83,7 @@ class TestImage:
         test_image = Image(file_name=image.file_name, location=image.loc, external_id=image.external_id)
 
         # Act and assert
-        with raises(ValueError):
+        with raises(ImageError):
             test_image.image_id = "ec2aac06-c261-3669-b8bd-4486a54ce740"
 
     @staticmethod
@@ -200,7 +201,7 @@ class TestImage:
         # Act and Assert
         test_image.dump(cat)
 
-        with raises(ValueError):
+        with raises(ImageError):
             test_image.dump(cat)
 
     @staticmethod

--- a/tests/datasets/test_info.py
+++ b/tests/datasets/test_info.py
@@ -268,6 +268,6 @@ class TestMergeDatasetCategories:
         merge = get_merged_categories(cat_1, cat_2)
 
         # Act & Assert
-        with pytest.raises(PermissionError):
+        with pytest.raises(RuntimeWarning):
             merge.filter_categories(categories="BAZ")
             merge.set_cat_to_sub_cat({"FOO": "FOO_1"})

--- a/tests/extern/test_tessocr.py
+++ b/tests/extern/test_tessocr.py
@@ -26,7 +26,7 @@ import pytest
 from deepdoctection.extern.base import DetectionResult
 from deepdoctection.extern.tessocr import TesseractOcrDetector, tesseract_line_to_detectresult
 from deepdoctection.utils.detection_types import ImageType
-from deepdoctection.utils.file_utils import TesseractNotFound
+from deepdoctection.utils.error import DependencyError
 from tests.data import Annotations
 
 from .data import WORD_RESULTS
@@ -66,7 +66,7 @@ class TestTesseractOcrDetector:
         """
 
         # Act and Assert
-        with pytest.raises(TesseractNotFound):
+        with pytest.raises(DependencyError):
             TesseractOcrDetector(path_yaml=path_to_tesseract_yaml)
 
     @staticmethod


### PR DESCRIPTION
This PR serves to harmonize exceptions through the entire library. 

In addition, the following exceptions have been added, which are used in important places:

- `AnnotationError`
- `BoundingBoxError`
- `ImageError`
- `UUIDError`
- `DependencyError`

A separate error module in the utils package collects all the library's own error formats.