### PR TITLE
Do not disable existing loggers

### DIFF
--- a/deepdoctection/utils/logger.py
+++ b/deepdoctection/utils/logger.py
@@ -134,6 +134,7 @@ class FileFormatter(logging.Formatter):
 _LOG_DIR = None
 _CONFIG_DICT: Dict[str, Any] = {
     "version": 1,
+    "disable_existing_loggers": False,
     "filters": {"customfilter": {"()": lambda: CustomFilter()}},  # pylint: disable=W0108
     "formatters": {
         "streamformatter": {"()": lambda: StreamFormatter(datefmt="%m%d %H:%M.%S")},


### PR DESCRIPTION
As a library deepdoctection should co-operate with any loggers that users already have

It is annoying that Python has this as default `True` and causes a lot of time hunting it down