### PR TITLE
restrict to numpy<2.0 [setup][force ci]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ _DEPS = [
     "lxml>=4.9.1",
     "mock==4.0.3",
     "networkx>=2.7.1",
-    "numpy>=1.21",
+    "numpy>=1.21,<2.0",
     "opencv-python==4.8.0.76",  # this is not required anymore, but we keep its version as a reference
     "packaging>=20.0",
     "Pillow>=10.0.0",


### PR DESCRIPTION
Numpy 2.0, released last week causes serious errors with Tensorflow and must be disallowed. 
