### PR TITLE
PDF image conversion

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,15 +102,15 @@ jobs:
               extras: pt,
               test: test,
               test_cases: test-pt }
-          #- { name: '3.12-pt',
-          #    python: '3.12',
-          #    pip: '24.0',
-          #    os: ubuntu-22.04,
-          #    dll: 'torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu',
-          #    detectron2: true,
-          #    extras: pt,
-          #    test: test,
-          #    test_cases: test-pt }
+          - { name: '3.12-pt',
+              python: '3.12',
+              pip: '24.0',
+              os: ubuntu-22.04,
+              dll: 'torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu',
+              detectron2: true,
+              extras: pt,
+              test: test,
+              test_cases: test-pt }
 
     steps:
       - uses: actions/checkout@v3

--- a/deepdoctection/__init__.py
+++ b/deepdoctection/__init__.py
@@ -6,6 +6,7 @@ Init file for deepdoctection package. This file is used to import all submodules
 """
 
 import importlib.util
+import os
 
 # Before doing anything else, check if the .env file exists and load it
 if importlib.util.find_spec("dotenv") is not None:
@@ -423,6 +424,9 @@ _IMPORT_STRUCTURE = {
 env_info = collect_env_info()
 logger.debug(LoggingRecord(msg=env_info))
 auto_select_pdf_render_framework()
+os.environ["DPI"] = "300"
+os.environ["IMAGE_WIDTH"] = ""
+os.environ["IMAGE_HEIGHT"] = ""
 
 # Direct imports for type-checking
 if TYPE_CHECKING:

--- a/deepdoctection/analyzer/dd.py
+++ b/deepdoctection/analyzer/dd.py
@@ -32,7 +32,6 @@ from ..extern.pt.ptutils import get_torch_device
 from ..extern.tp.tfutils import disable_tp_layer_logging, get_tf_device
 from ..pipe.doctectionpipe import DoctectionPipe
 from ..utils.env_info import ENV_VARS_TRUE
-from ..utils.error import DependencyError
 from ..utils.file_utils import tensorpack_available
 from ..utils.fs import get_configs_dir_path, get_package_path, maybe_copy_config_to_cache
 from ..utils.logger import LoggingRecord, logger
@@ -118,13 +117,15 @@ def get_dd_analyzer(
     :return: A DoctectionPipe instance with given configs
     """
     config_overwrite = [] if config_overwrite is None else config_overwrite
-    lib = "TF" if os.environ.get("DD_USE_TF", "0") in ENV_VARS_TRUE else "PT"
-    if lib == "TF":
+    if os.environ.get("DD_USE_TF", "0") in ENV_VARS_TRUE:
+        lib = "TF"
         device = get_tf_device()
-    elif lib == "PT":
+    elif os.environ.get("DD_USE_TORCH", "0") in ENV_VARS_TRUE:
+        lib = "PT"
         device = get_torch_device()
     else:
-        raise DependencyError("At least one of the env variables DD_USE_TF or DD_USE_TORCH must be set.")
+        lib = None
+        device = None
     dd_one_config_path = maybe_copy_config_to_cache(
         get_package_path(), get_configs_dir_path() / "dd", _DD_ONE, reset_config_file
     )

--- a/deepdoctection/analyzer/factory.py
+++ b/deepdoctection/analyzer/factory.py
@@ -48,6 +48,7 @@ from ..pipe.segment import PubtablesSegmentationService, TableSegmentationServic
 from ..pipe.sub_layout import DetectResultGenerator, SubImageLayoutService
 from ..pipe.text import TextExtractionService
 from ..pipe.transform import SimpleTransformService
+from ..utils.error import DependencyError
 from ..utils.file_utils import detectron2_available
 from ..utils.fs import get_configs_dir_path
 from ..utils.metacfg import AttrDict
@@ -61,8 +62,6 @@ with try_import() as image_guard:
 __all__ = [
     "ServiceFactory",
 ]
-
-# from ._config import cfg
 
 
 class ServiceFactory:
@@ -94,6 +93,8 @@ class ServiceFactory:
         :param config: configuration object
         :param mode: either `LAYOUT`,`CELL` or `ITEM`
         """
+        if config.LIB is None:
+            raise DependencyError("At least one of the env variables DD_USE_TF or DD_USE_TORCH must be set.")
         weights = (
             getattr(config.TF, mode).WEIGHTS
             if config.LIB == "TF"
@@ -310,6 +311,8 @@ class ServiceFactory:
                 config_overwrite=[f"LANGUAGES={config.LANGUAGE}"] if config.LANGUAGE is not None else None,
             )
         if config.OCR.USE_DOCTR:
+            if config.LIB is None:
+                raise DependencyError("At least one of the env variables DD_USE_TF or DD_USE_TORCH must be set.")
             weights = (
                 config.OCR.WEIGHTS.DOCTR_RECOGNITION.TF
                 if config.LIB == "TF"
@@ -353,6 +356,8 @@ class ServiceFactory:
         :param config: configuration object
         :return: DoctrTextlineDetector
         """
+        if config.LIB is None:
+            raise DependencyError("At least one of the env variables DD_USE_TF or DD_USE_TORCH must be set.")
         weights = config.OCR.WEIGHTS.DOCTR_WORD.TF if config.LIB == "TF" else config.OCR.WEIGHTS.DOCTR_WORD.PT
         weights_path = ModelDownloadManager.maybe_download_weights_and_configs(weights)
         profile = ModelCatalog.get_profile(weights)

--- a/deepdoctection/datapoint/convert.py
+++ b/deepdoctection/datapoint/convert.py
@@ -154,7 +154,9 @@ def convert_pdf_bytes_to_np_array(pdf_bytes: bytes, dpi: Optional[int] = None) -
     return np_array.astype(uint8)
 
 
-def convert_pdf_bytes_to_np_array_v2(pdf_bytes: bytes, dpi: Optional[int] = 200) -> PixelValues:
+def convert_pdf_bytes_to_np_array_v2(
+    pdf_bytes: bytes, dpi: Optional[int] = None, width: Optional[int] = None, height: Optional[int] = None
+) -> PixelValues:
     """
     Converts a pdf passed as bytes into a numpy array. We use poppler or pdfmium to convert the pdf to an image.
     If both is available you can steer the selection of the render engine with environment variables:
@@ -165,17 +167,21 @@ def convert_pdf_bytes_to_np_array_v2(pdf_bytes: bytes, dpi: Optional[int] = 200)
     :param pdf_bytes: A pdf as bytes object. A byte representation can from a pdf file can be generated e.g. with
                       `utils.fs.load_bytes_from_pdf_file`
     :param dpi: The dpi value of the resulting output image. For high resolution set dpi=300.
+    :param width: The width of the resulting output image. This option does only work when using Poppler as
+    PDF renderer
+    :param height: The height of the resulting output image. This option does only work when using Poppler as
+    PDF renderer
     :return: Image as numpy array.
     """
 
-    with BytesIO(pdf_bytes) as pdf_file:
-        pdf = PdfReader(pdf_file).pages[0]
-    shape = pdf.mediabox  # pylint: disable=E1101
-    height = shape[3] - shape[1]
-    width = shape[2] - shape[0]
-
     if dpi is None:
-        return pdf_to_np_array(pdf_bytes, size=(int(width), int(height)))
+        if width is None or height is None:
+            with BytesIO(pdf_bytes) as pdf_file:
+                pdf = PdfReader(pdf_file).pages[0]
+            shape = pdf.mediabox  # pylint: disable=E1101
+            height = shape[3] - shape[1]
+            width = shape[2] - shape[0]
+        return pdf_to_np_array(pdf_bytes, size=(int(width), int(height)))  # type: ignore
     return pdf_to_np_array(pdf_bytes, dpi=dpi)
 
 

--- a/deepdoctection/datapoint/image.py
+++ b/deepdoctection/datapoint/image.py
@@ -153,7 +153,7 @@ class Image:
             self.set_width_height(self._image.shape[1], self._image.shape[0])
             self._self_embedding()
         elif isinstance(image, bytes):
-            self._image = convert_pdf_bytes_to_np_array_v2(image, dpi=int(environ["DPI"]))  # type: ignore
+            self._image = convert_pdf_bytes_to_np_array_v2(image, dpi=int(environ["DPI"]))
             self.set_width_height(self._image.shape[1], self._image.shape[0])
             self._self_embedding()
         else:

--- a/deepdoctection/datapoint/image.py
+++ b/deepdoctection/datapoint/image.py
@@ -153,7 +153,7 @@ class Image:
             self.set_width_height(self._image.shape[1], self._image.shape[0])
             self._self_embedding()
         elif isinstance(image, bytes):
-            self._image = convert_pdf_bytes_to_np_array_v2(image, dpi=environ.get("DPI", 300))  # type: ignore
+            self._image = convert_pdf_bytes_to_np_array_v2(image, dpi=int(environ["DPI"]))  # type: ignore
             self.set_width_height(self._image.shape[1], self._image.shape[0])
             self._self_embedding()
         else:

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -248,13 +248,13 @@ class Layout(ImageAnnotationBaseView):
             )
         else:
             characters, ann_ids, token_classes, token_tags, token_classes_ids, token_tag_ids = (
-                [],
-                [],
-                [],
-                [],
-                [],
-                [],
-            )  # type: ignore
+                [], # type: ignore
+                [], # type: ignore
+                [], # type: ignore
+                [], # type: ignore
+                [], # type: ignore
+                [], # type: ignore
+            )
         return {
             "text": " ".join(characters),
             "words": characters,
@@ -382,9 +382,9 @@ class Table(Layout):
         for cell in row_cells:
             for header in column_header_cells:
                 if (
-                    cell.column_number == header.column_number
+                    cell.column_number == header.column_number  # type: ignore
                     and cell.annotation_id != header.annotation_id  # type: ignore
-                ):  # type: ignore
+                ):
                     kv_dict[(header.column_number, header.text)] = cell.text  # type: ignore
                     break
         return kv_dict

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -247,7 +247,14 @@ class Layout(ImageAnnotationBaseView):
                 ]
             )
         else:
-            characters, ann_ids, token_classes, token_tags, token_classes_ids, token_tag_ids = [], [], [], [], [], []
+            characters, ann_ids, token_classes, token_tags, token_classes_ids, token_tag_ids = (
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+            )  # type: ignore
         return {
             "text": " ".join(characters),
             "words": characters,
@@ -330,7 +337,7 @@ class Table(Layout):
         :return: A list of `Cell` objects that are row headers.
         """
         all_relation_ids = self.get_relationship(Relationships.CHILD)
-        all_cells: list[Cell] = self.base_page.get_annotation( # type: ignore
+        all_cells: list[Cell] = self.base_page.get_annotation(  # type: ignore
             category_names=[LayoutType.CELL, CellType.SPANNING], annotation_ids=all_relation_ids
         )
         row_header_cells = list(filter(lambda cell: CellType.ROW_HEADER in cell.sub_categories, all_cells))
@@ -366,18 +373,18 @@ class Table(Layout):
             category_names=[LayoutType.CELL, CellType.SPANNING], annotation_ids=all_relation_ids
         )
         row_cells = list(
-            filter(
-                lambda c: row_number in (c.row_number, c.row_number + c.row_span), all_cells  # type: ignore
-            )
+            filter(lambda c: row_number in (c.row_number, c.row_number + c.row_span), all_cells)  # type: ignore
         )
-        row_cells.sort(key=lambda c: c.column_number) # type: ignore
+        row_cells.sort(key=lambda c: c.column_number)  # type: ignore
         column_header_cells = self.column_header_cells
 
         kv_dict: Mapping[str, str] = {}
         for cell in row_cells:
             for header in column_header_cells:
-                if (cell.column_number == header.column_number and  # type: ignore
-                        cell.annotation_id != header.annotation_id):  # type: ignore
+                if (
+                    cell.column_number == header.column_number
+                    and cell.annotation_id != header.annotation_id  # type: ignore
+                ):  # type: ignore
                     kv_dict[(header.column_number, header.text)] = cell.text  # type: ignore
                     break
         return kv_dict

--- a/deepdoctection/extern/model.py
+++ b/deepdoctection/extern/model.py
@@ -24,7 +24,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Mapping, Optional, Union
 
 import jsonlines
-from huggingface_hub import cached_download, hf_hub_url  # type: ignore
+from huggingface_hub import hf_hub_download
 from tabulate import tabulate
 from termcolor import colored
 
@@ -136,51 +136,6 @@ class ModelCatalog:
             dl_library="TF",
             model_wrapper="TPFrcnnDetector",
         ),
-        "item/model-1620000.data-00000-of-00001": ModelProfile(
-            name="item/model-1620000.data-00000-of-00001",
-            description="Tensorpack row/column detection model trained on Pubtabnet",
-            config="dd/tp/conf_frcnn_rows.yaml",
-            size=[823546048, 25787],
-            tp_model=True,
-            hf_repo_id="deepdoctection/tp_casc_rcnn_X_32xd4_50_FPN_GN_2FC_pubtabnet_rc",
-            hf_model_name="model-1620000",
-            hf_config_file=["conf_frcnn_rows.yaml"],
-            categories={1: LayoutType.ROW, 2: LayoutType.COLUMN},
-            dl_library="TF",
-            model_wrapper="TPFrcnnDetector",
-        ),
-        "layout/model-800000.data-00000-of-00001": ModelProfile(
-            name="layout/model-800000.data-00000-of-00001",
-            description="Tensorpack layout detection model trained on Publaynet",
-            config="dd/tp/conf_frcnn_layout.yaml",
-            size=[823656748, 25796],
-            tp_model=True,
-            hf_repo_id="deepdoctection/tp_casc_rcnn_X_32xd4_50_FPN_GN_2FC_publaynet",
-            hf_model_name="model-800000",
-            hf_config_file=["conf_frcnn_layout.yaml"],
-            dl_library="TF",
-            categories={
-                1: LayoutType.TEXT,
-                2: LayoutType.TITLE,
-                3: LayoutType.LIST,
-                4: LayoutType.TABLE,
-                5: LayoutType.FIGURE,
-            },
-            model_wrapper="TPFrcnnDetector",
-        ),
-        "cell/model-1800000.data-00000-of-00001": ModelProfile(
-            name="cell/model-1800000.data-00000-of-00001",
-            description="Tensorpack cell detection model trained on Pubtabnet",
-            config="dd/tp/conf_frcnn_cell.yaml",
-            size=[823509160, 25905],
-            tp_model=True,
-            hf_repo_id="deepdoctection/tp_casc_rcnn_X_32xd4_50_FPN_GN_2FC_pubtabnet_c",
-            hf_model_name="model-1800000",
-            hf_config_file=["conf_frcnn_cell.yaml"],
-            categories={1: LayoutType.CELL},
-            dl_library="TF",
-            model_wrapper="TPFrcnnDetector",
-        ),
         "layout/d2_model_0829999_layout_inf_only.pt": ModelProfile(
             name="layout/d2_model_0829999_layout_inf_only.pt",
             description="Detectron2 layout detection model trained on Publaynet",
@@ -189,25 +144,6 @@ class ModelCatalog:
             tp_model=False,
             hf_repo_id="deepdoctection/d2_casc_rcnn_X_32xd4_50_FPN_GN_2FC_publaynet_inference_only",
             hf_model_name="d2_model_0829999_layout_inf_only.pt",
-            hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
-            categories={
-                1: LayoutType.TEXT,
-                2: LayoutType.TITLE,
-                3: LayoutType.LIST,
-                4: LayoutType.TABLE,
-                5: LayoutType.FIGURE,
-            },
-            dl_library="PT",
-            model_wrapper="D2FrcnnDetector",
-        ),
-        "layout/d2_model_0829999_layout.pth": ModelProfile(
-            name="layout/d2_model_0829999_layout.pth",
-            description="Detectron2 layout detection model trained on Publaynet. Checkpoint for resuming training",
-            config="dd/d2/layout/CASCADE_RCNN_R_50_FPN_GN.yaml",
-            size=[548377327],
-            tp_model=False,
-            hf_repo_id="deepdoctection/d2_casc_rcnn_X_32xd4_50_FPN_GN_2FC_publaynet_inference_only",
-            hf_model_name="d2_model_0829999_layout.pth",
             hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
             categories={
                 1: LayoutType.TEXT,
@@ -263,32 +199,6 @@ class ModelCatalog:
             categories={1: LayoutType.CELL},
             dl_library="PT",
             model_wrapper="D2FrcnnTracingDetector",
-        ),
-        "cell/d2_model_1849999_cell.pth": ModelProfile(
-            name="cell/d2_model_1849999_cell.pth",
-            description="Detectron2 cell detection inference only model trained on Pubtabnet",
-            config="dd/d2/cell/CASCADE_RCNN_R_50_FPN_GN.yaml",
-            size=[548279023],
-            tp_model=False,
-            hf_repo_id="deepdoctection/d2_casc_rcnn_X_32xd4_50_FPN_GN_2FC_pubtabnet_c_inference_only",
-            hf_model_name="cell/d2_model_1849999_cell.pth",
-            hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
-            categories={1: LayoutType.CELL},
-            dl_library="PT",
-            model_wrapper="D2FrcnnDetector",
-        ),
-        "item/d2_model_1639999_item.pth": ModelProfile(
-            name="item/d2_model_1639999_item.pth",
-            description="Detectron2 item detection model trained on Pubtabnet",
-            config="dd/d2/item/CASCADE_RCNN_R_50_FPN_GN.yaml",
-            size=[548303599],
-            tp_model=False,
-            hf_repo_id="deepdoctection/d2_casc_rcnn_X_32xd4_50_FPN_GN_2FC_pubtabnet_rc_inference_only",
-            hf_model_name="d2_model_1639999_item.pth",
-            hf_config_file=["Base-RCNN-FPN.yaml", "CASCADE_RCNN_R_50_FPN_GN.yaml"],
-            categories={1: LayoutType.ROW, 2: LayoutType.COLUMN},
-            dl_library="PT",
-            model_wrapper="D2FrcnnDetector",
         ),
         "item/d2_model_1639999_item_inf_only.pt": ModelProfile(
             name="item/d2_model_1639999_item_inf_only.pt",
@@ -1232,20 +1142,18 @@ class ModelDownloadManager:
     def _load_from_hf_hub(
         repo_id: str, file_name: str, cache_directory: PathLikeOrStr, force_download: bool = False
     ) -> int:
-        url = hf_hub_url(repo_id=repo_id, filename=file_name)
         token = os.environ.get("HF_CREDENTIALS", None)
-        f_path = cached_download(
-            url,
-            cache_dir=cache_directory,
-            force_filename=file_name,
-            force_download=force_download,
-            token=token,
-            legacy_cache_layout=True,
-        )
+        f_path = hf_hub_download(repo_id,
+                                 file_name,
+                                 local_dir=cache_directory, # type: ignore
+                                 force_filename=file_name,
+                                 force_download=force_download,
+                                 token=token,
+                                 )
         if f_path:
             stat_info = os.stat(f_path)
             size = stat_info.st_size
 
-            assert size > 0, f"Downloaded an empty file from {url}!"
+            assert size > 0, f"Downloaded an empty file from {f_path}!"
             return size
         raise TypeError("Returned value from cached_download cannot be Null")

--- a/deepdoctection/mapper/match.py
+++ b/deepdoctection/mapper/match.py
@@ -101,17 +101,6 @@ def match_anns_by_intersection(
         ]
     )
 
-    # second try, if ann has empty image
-    n_dim = child_ann_boxes.ndim
-    if n_dim != 2:
-        child_ann_boxes = np.array(
-            [
-                ann.bounding_box.transform(dp.width, dp.height, absolute_coords=True).to_list(mode="xyxy")
-                for ann in child_anns
-                if ann.bounding_box is not None
-            ]
-        )
-
     parent_anns = dp.get_annotation(annotation_ids=parent_ann_ids, category_names=parent_ann_category_names)
     parent_ann_boxes = np.array(
         [
@@ -119,17 +108,6 @@ def match_anns_by_intersection(
             for ann in parent_anns
         ]
     )
-
-    # same for parent
-    n_dim = parent_ann_boxes.ndim
-    if n_dim != 2:
-        parent_ann_boxes = np.array(
-            [
-                ann.bounding_box.transform(dp.width, dp.height, absolute_coords=True).to_list(mode="xyxy")
-                for ann in parent_anns
-                if ann.bounding_box is not None
-            ]
-        )
 
     if matching_rule in ["iou"] and parent_anns and child_anns:
         iou_matrix = iou(child_ann_boxes, parent_ann_boxes)

--- a/deepdoctection/mapper/misc.py
+++ b/deepdoctection/mapper/misc.py
@@ -38,12 +38,20 @@ with try_import() as import_guard:
     from lxml import etree  # pylint: disable=W0611
 
 
-def to_image(dp: Union[str, Mapping[str, Union[str, bytes]]], dpi: Optional[int] = None) -> Optional[Image]:
+def to_image(
+    dp: Union[str, Mapping[str, Union[str, bytes]]],
+    dpi: Optional[int] = None,
+    width: Optional[int] = None,
+    height: Optional[int] = None,
+) -> Optional[Image]:
     """
     Mapping an input from `dataflow.SerializerFiles` or similar to an Image
 
     :param dp: Image
     :param dpi: dot per inch definition for pdf resolution when converting to numpy array
+    :param width: target width of the image. This option does only work when using Poppler as PDF renderer
+    :param height: target width of the image. This option does only work when using Poppler as PDF renderer
+    :param height: target height of the image
     :return: Image
     """
 
@@ -77,7 +85,9 @@ def to_image(dp: Union[str, Mapping[str, Union[str, bytes]]], dpi: Optional[int]
                 dp_image.pdf_bytes = dp.get("pdf_bytes")
                 if dp_image.pdf_bytes is not None:
                     if isinstance(dp_image.pdf_bytes, bytes):
-                        dp_image.image = convert_pdf_bytes_to_np_array_v2(dp_image.pdf_bytes, dpi=dpi)
+                        dp_image.image = convert_pdf_bytes_to_np_array_v2(
+                            dp_image.pdf_bytes, dpi=dpi, width=width, height=height
+                        )
             elif image_bytes is not None:
                 dp_image.image = convert_bytes_to_np_array(image_bytes)
             else:

--- a/deepdoctection/mapper/pubstruct.py
+++ b/deepdoctection/mapper/pubstruct.py
@@ -393,7 +393,7 @@ def pub_to_image_uncur(  # pylint: disable=R0914
             np_image = load_image_from_file(dp["filename"])
         if is_file_extension(dp["filename"], ".pdf"):
             pdf_bytes = load_bytes_from_pdf_file(dp["filename"])
-            np_image = convert_pdf_bytes_to_np_array_v2(pdf_bytes)
+            np_image = convert_pdf_bytes_to_np_array_v2(pdf_bytes, dpi=200)
             dp = _convert_boxes(dp, np_image.shape[0])
 
         if load_image and np_image is not None:

--- a/deepdoctection/pipe/segment.py
+++ b/deepdoctection/pipe/segment.py
@@ -1191,17 +1191,13 @@ class PubtablesSegmentationService(PipelineComponent):
                                 if key[idx] == item_number:
                                     cell_ann = dp.get_annotation(annotation_ids=value)[0]
                                     self.dp_manager.set_category_annotation(
-                                        item_header_cell_name,
-                                        None,
-                                        item_header_cell_name,
-                                        cell_ann.annotation_id
+                                        item_header_cell_name, None, item_header_cell_name, cell_ann.annotation_id
                                     )
                                 else:
                                     cell_ann = dp.get_annotation(annotation_ids=value)[0]
-                                    self.dp_manager.set_category_annotation(item_header_cell_name,
-                                                                            None,
-                                                                            CellType.BODY,
-                                                                            cell_ann.annotation_id)
+                                    self.dp_manager.set_category_annotation(
+                                        item_header_cell_name, None, CellType.BODY, cell_ann.annotation_id
+                                    )
 
             # TODO: the summaries should be sub categories of the underlying ann
             self.dp_manager.set_summary_annotation(

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _DEPS = [
     "apted==1.0.3",
     "catalogue==2.0.10",
     "distance==0.1.3",
-    "huggingface_hub>=0.12.0,<0.26",
+    "huggingface_hub>=0.26.0",
     "importlib-metadata>=5.0.0",
     "jsonlines==3.1.0",
     "lazy-imports==0.3.1",

--- a/tests/analyzer/test_dd.py
+++ b/tests/analyzer/test_dd.py
@@ -44,7 +44,7 @@ def test_dd_analyzer_builds_and_process_image_layout_correctly() -> None:
     page = output[0]
     assert isinstance(page, Page)
     # 9 for d2 and 10 for tp model
-    assert len(page.layouts) in {9, 10, 12, 16}
+    assert len(page.layouts) in {9, 10, 12, 13, 16}
     assert len(page.tables) == 1
     assert page.height == 2339
     assert page.width == 1654
@@ -95,8 +95,9 @@ def test_dd_analyzer_builds_and_process_image_layout_and_tables_correctly() -> N
     assert len(page.layouts) in {9, 10, 12, 16}
     assert len(page.tables) == 1
     # 15 cells for d2 and 16 for tp model
-    assert len(page.tables[0].cells) in {15, 16}  # type: ignore
+    assert len(page.tables[0].cells) in {14, 15, 16}  # type: ignore
     # first html for tp model, second for d2 model
+    print(page.tables[0].html)
     assert page.tables[0].html in {
         "<table><tr><td></td><td></td></tr><tr><td></td><td></td></tr><tr><td></td><td></td>"
         "</tr><tr><td></td><td></td></tr><tr><td></td><td></td></tr><tr><td></td><td></td>"
@@ -104,6 +105,9 @@ def test_dd_analyzer_builds_and_process_image_layout_and_tables_correctly() -> N
         "<table><tr><td></td><td rowspan=2></td></tr><tr><td></td></tr><tr><td></td><td></td></tr><tr><td></td><td>"
         "</td></tr><tr><td></td><td></td></tr><tr><td></td><td></td></tr><tr><td></td><td></td></tr><tr><td></td>"
         "<td></td></tr></table>",
+        "<table><tr><td></td><td></td></tr><tr><td rowspan=2></td><td></td></tr><tr><td></td></tr><tr><td></td><td>"
+        "</td></tr><tr><td></td><td></td></tr><tr><td></td><td></td></tr><tr><td></td><td></td></tr><tr><td></td><td>"
+        "</td></tr></table>",
     }
     assert page.height == 2339
     assert page.width == 1654
@@ -165,9 +169,8 @@ def test_dd_analyzer_builds_and_process_image_correctly() -> None:
     assert len(page.layouts) in {9, 10, 12, 16}
     assert len(page.tables) == 1
     # 15 cells for d2 and 16 for tp model
-    assert len(page.tables[0].cells) in {15, 16}  # type: ignore
+    assert len(page.tables[0].cells) in {13, 15, 16}  # type: ignore
     # first html for tp model, second for d2 model
-
     assert page.tables[0].html in {
         "<table><tr><td>Jahresdurchschnitt der Mitarbeiterzahl</td><td>139</td></tr><tr>"
         "<td>Gesamtvergiitung ?</td><td>EUR 15.315.952</td></tr><tr><td>Fixe Vergiitung</td>"
@@ -186,11 +189,18 @@ def test_dd_analyzer_builds_and_process_image_correctly() -> None:
         "2.164.096</td></tr><tr><td>davon: Carried Interest</td><td>EURO</td></tr><tr><td>Gesamtvergiitung fiir "
         "Senior Management °</td><td>EUR 1.468.434</td></tr><tr><td>Gesamtvergiitung fiir sonstige Risikotrager"
         "</td><td>EUR 324.229</td></tr><tr><td></td><td></td></tr></table>",
+        "<table><tr><td>Jahresdurchschnitt der Mitarbeiterzahl</td><td>139</td></tr><tr><td rowspan=2>Gesamtvergiitung"
+        " ? Fixe Vergiitung</td><td>EUR 15.315.952</td></tr><tr><td>EUR 13.151.856</td></tr><tr><td>Variable"
+        " Vergiitung</td><td>EUR 2.164.096</td></tr><tr><td>davon: Carried Interest</td><td>EURO</td></tr><tr><td>"
+        "Gesamtvergiitung fiir Senior Management °</td><td>EUR 1.468.434</td></tr><tr><td>Gesamtvergiitung fuir"
+        " sonstige Risikotrager</td><td>EUR 324.229</td></tr><tr><td>Gesamtvergiitung fir Mitarbeiter mit"
+        " Kontrollfunktionen</td><td>EUR 554.046</td></tr></table>",
+        "<table><tr><td>Jahresdurchschnitt der Mitarbeiterzahl</td><td>139</td></tr><tr><td>Gesamtvergiitung ?</td><td rowspan=2>EUR 15.315.952 EUR 13.151.856</td></tr><tr><td>Fixe Vergiitung</td></tr><tr><td>Variable Vergiitung</td><td>EUR 2.164.096</td></tr><tr><td>davon: Carried Interest</td><td>EURO</td></tr><tr><td>Gesamtvergiitung fiir Senior Management °</td><td>EUR 1.468.434</td></tr><tr><td>Gesamtvergiitung fuir sonstige Risikotrager</td><td>EUR 324.229</td></tr><tr><td>Gesamtvergiitung fir Mitarbeiter mit Kontrollfunktionen</td><td>EUR 554.046</td></tr></table>",  # pylint: disable=C0301
     }
     assert page.height == 2339
     assert page.width == 1654
     # first number for tp model, second for pt model
-    assert len(page.text) in {5042, 5043, 5044, 5045, 5153}
+    assert len(page.text) in {5042, 5043, 5044, 5046, 5045, 5153}
     text_ = page.text_
     assert text_["text"] == page._make_text(line_break=False)  # pylint: disable=W0212
     assert len(text_["words"]) in {631, 632, 642}

--- a/tests/datapoint/test_convert.py
+++ b/tests/datapoint/test_convert.py
@@ -51,7 +51,7 @@ def test_convert_pdf_bytes_to_np_array_v2_using_pdfmium2(pdf_page: TestPdfPage) 
     os.environ["USE_DD_PDFIUM"] = "True"
 
     # Act
-    np_array = convert_pdf_bytes_to_np_array_v2(pdf_page.pdf_bytes)
+    np_array = convert_pdf_bytes_to_np_array_v2(pdf_page.pdf_bytes, dpi=200)
 
     # Assert
     assert np_array.shape == (2200, 1700, 3)

--- a/tests/datasets/instances/conftest.py
+++ b/tests/datasets/instances/conftest.py
@@ -33,3 +33,12 @@ def get_white_image(path: str) -> Optional[PixelValues]:
     if path:
         return np.ones((794, 596, 3), dtype=np.uint8) * 255  # type: ignore
     return None
+
+
+def get_white_image_pdf(path: str, dpi: int) -> Optional[PixelValues]:  # pylint: disable=W0613
+    """
+    white image
+    """
+    if path:
+        return np.ones((794, 596, 3), dtype=np.uint8) * 255  # type: ignore
+    return None

--- a/tests/datasets/instances/test_fintabnet.py
+++ b/tests/datasets/instances/test_fintabnet.py
@@ -26,11 +26,11 @@ from pytest import mark
 from deepdoctection.datasets import Fintabnet
 
 from ...test_utils import collect_datapoint_from_dataflow, get_test_path
-from .conftest import get_white_image
+from .conftest import get_white_image_pdf
 
 
 @mark.basic
-@patch("deepdoctection.mapper.pubstruct.convert_pdf_bytes_to_np_array_v2", MagicMock(side_effect=get_white_image))
+@patch("deepdoctection.mapper.pubstruct.convert_pdf_bytes_to_np_array_v2", MagicMock(side_effect=get_white_image_pdf))
 @patch("deepdoctection.mapper.pubstruct.load_bytes_from_pdf_file", MagicMock(return_value=b"\x01\x02"))
 @patch("deepdoctection.datasets.instances.fintabnet.set_mp_spawn", MagicMock())
 def test_dataset_fintabnet_returns_image() -> None:
@@ -50,7 +50,7 @@ def test_dataset_fintabnet_returns_image() -> None:
 
 
 @mark.basic
-@patch("deepdoctection.mapper.pubstruct.convert_pdf_bytes_to_np_array_v2", MagicMock(side_effect=get_white_image))
+@patch("deepdoctection.mapper.pubstruct.convert_pdf_bytes_to_np_array_v2", MagicMock(side_effect=get_white_image_pdf))
 @patch("deepdoctection.mapper.pubstruct.load_bytes_from_pdf_file", MagicMock(return_value=b"\x01\x02"))
 @patch("deepdoctection.datasets.instances.fintabnet.set_mp_spawn", MagicMock())
 def test_dataset_fintabnet_with_load_image_returns_image() -> None:


### PR DESCRIPTION
This PR refactors pdf to image conversion functions: 

For Poppler users one can convert PDF to image by passing width and height. 
The following ENV can be set:
- DPI
- IMAGE_WIDTH
- IMAGE_HEIGHT

The deprecated `cached_download` from `hu_hub` is being replaced by `hf_hub_download`.