### PR TITLE
Defaults in LMSequenceClassifierService

### DIFF
--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -248,12 +248,12 @@ class Layout(ImageAnnotationBaseView):
             )
         else:
             characters, ann_ids, token_classes, token_tags, token_classes_ids, token_tag_ids = (
-                [], # type: ignore
-                [], # type: ignore
-                [], # type: ignore
-                [], # type: ignore
-                [], # type: ignore
-                [], # type: ignore
+                [],  # type: ignore
+                [],  # type: ignore
+                [],  # type: ignore
+                [],  # type: ignore
+                [],  # type: ignore
+                [],  # type: ignore
             )
         return {
             "text": " ".join(characters),

--- a/deepdoctection/extern/model.py
+++ b/deepdoctection/extern/model.py
@@ -1143,13 +1143,14 @@ class ModelDownloadManager:
         repo_id: str, file_name: str, cache_directory: PathLikeOrStr, force_download: bool = False
     ) -> int:
         token = os.environ.get("HF_CREDENTIALS", None)
-        f_path = hf_hub_download(repo_id,
-                                 file_name,
-                                 local_dir=cache_directory, # type: ignore
-                                 force_filename=file_name,
-                                 force_download=force_download,
-                                 token=token,
-                                 )
+        f_path = hf_hub_download(
+            repo_id,
+            file_name,
+            local_dir=cache_directory,  # type: ignore
+            force_filename=file_name,
+            force_download=force_download,
+            token=token,
+        )
         if f_path:
             stat_info = os.stat(f_path)
             size = stat_info.st_size

--- a/deepdoctection/train/hf_layoutlm_train.py
+++ b/deepdoctection/train/hf_layoutlm_train.py
@@ -499,7 +499,9 @@ def train_hf_layoutlm(
         )
         pipeline_component_cls = pipeline_component_registry.get(pipeline_component_name)
         if dataset_type == DatasetType.SEQUENCE_CLASSIFICATION:
-            pipeline_component = pipeline_component_cls(tokenizer_fast, dd_model)
+            pipeline_component = pipeline_component_cls(tokenizer_fast,
+                                                        dd_model,
+                                                        use_other_as_default_category=True)
         else:
             pipeline_component = pipeline_component_cls(
                 tokenizer_fast,


### PR DESCRIPTION
This PR assigns a default document type in `LMSequenceClassifierService` in the rare occasion, that a page does not contain any words. The document type will be 'other' and receive a category_id if the value is provided in category of the inference model.
