### PR TITLE
Replace fasttext with fastest-wheel 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ _DEPS = [
     "tf2onnx>=1.9.2",
     "python-doctr==0.8.1",
     "fasttext==0.9.2",
+    "fasttext-wheel",
     # dev dependencies
     "python-dotenv==1.0.0",
     "click",  # version will not break black
@@ -147,7 +148,7 @@ dist_deps = deps_list(
 additional_deps = deps_list(
     "boto3",
     "pdfplumber",
-    "fasttext",
+    "fasttext-wheel",
     "jdeskew",
     "apted",
     "distance",

--- a/tests/extern/test_fastlang.py
+++ b/tests/extern/test_fastlang.py
@@ -87,4 +87,4 @@ class TestFasttextLangDetector:
 
         # Assert
         assert result.text == "ita"
-        assert 0.9 <= result.score <= 1.0
+        assert 0.9 <= result.score <= 1.0  # type: ignore

--- a/tests/extern/test_fastlang.py
+++ b/tests/extern/test_fastlang.py
@@ -63,3 +63,27 @@ class TestFasttextLangDetector:
         # Assert
         assert result.text == "ita"
         assert result.score == 0.99414486
+
+
+    @staticmethod
+    @mark.additional
+    def test_non_mock_fasttext_lang_detector_predicts_language() -> None:
+        """
+        Detector calls model.predict(text_string) and processes returned results correctly. This test case does not use
+        a mock model.
+        """
+
+        # Arrange
+        path_weights = ModelCatalog.get_full_path_weights("fasttext/lid.176.bin")
+        profile = ModelCatalog.get_profile("fasttext/lid.176.bin")
+
+        assert profile.categories
+        assert profile.categories_orig
+        fasttest_predictor = FasttextLangDetector(path_weights, profile.categories, profile.categories_orig)
+
+        # Act
+        result = fasttest_predictor.predict("Un leggero dialetto italiano")
+
+        # Assert
+        assert result.text == "ita"
+        assert 0.9 <= result.score <= 1.0

--- a/tests/extern/test_fastlang.py
+++ b/tests/extern/test_fastlang.py
@@ -27,7 +27,7 @@ from numpy import float32
 from pytest import mark
 
 from deepdoctection.extern.fastlang import FasttextLangDetector
-from deepdoctection.extern.model import ModelCatalog
+from deepdoctection.extern.model import ModelCatalog, ModelDownloadManager
 
 
 def get_mock_lang_detect_result(text_string: str) -> Tuple[Tuple[str], npt.NDArray[float32]]:  # pylint: disable = W0613
@@ -76,6 +76,7 @@ class TestFasttextLangDetector:
         # Arrange
         path_weights = ModelCatalog.get_full_path_weights("fasttext/lid.176.bin")
         profile = ModelCatalog.get_profile("fasttext/lid.176.bin")
+        ModelDownloadManager.maybe_download_weights_and_configs("fasttext/lid.176.bin")
 
         assert profile.categories
         assert profile.categories_orig


### PR DESCRIPTION
The PR swaps `fasttext` with `fasttext-wheel` in the setup. 

Fasttext on latest Ubuntu fails to build in default setting due to the latest gcc-compiler.
`fastest-wheel` installs pre-built binaries.