### PR TITLE
Adding inbound filter to pipeline component

### DIFF
--- a/deepdoctection/pipe/base.py
+++ b/deepdoctection/pipe/base.py
@@ -33,7 +33,7 @@ from ..mapper.misc import curry
 from ..utils.context import timed_operation
 from ..utils.identifier import get_uuid_from_str
 from ..utils.settings import ObjectTypes
-from ..utils.types import DP, BaseExceptionType, S, T
+from ..utils.types import DP
 from .anngen import DatapointManager
 
 

--- a/deepdoctection/pipe/base.py
+++ b/deepdoctection/pipe/base.py
@@ -100,7 +100,7 @@ class PipelineComponent(ABC):
 
         :param filter_func: A function that takes an image datapoint and returns a boolean value
         """
-        self.filter_func = filter_func
+        self.filter_func = filter_func # type: ignore
 
     @abstractmethod
     def serve(self, dp: Image) -> None:

--- a/deepdoctection/pipe/base.py
+++ b/deepdoctection/pipe/base.py
@@ -77,7 +77,7 @@ class PipelineComponent(ABC):
         self.service_id = self.get_service_id()
         self.dp_manager = DatapointManager(self.service_id, model_id)
         self.timer_on = False
-        self.maybe_filter_func: Callable[[DP], bool] = lambda dp: True
+        self.filter_func: Callable[[DP], bool] = lambda dp: False
 
     def set_inbound_filter(self, filter_func: Callable[[DP], bool]) -> None:
         """
@@ -100,7 +100,7 @@ class PipelineComponent(ABC):
 
         :param filter_func: A function that takes an image datapoint and returns a boolean value
         """
-        self.maybe_filter_func = filter_func
+        self.filter_func = filter_func
 
     @abstractmethod
     def serve(self, dp: Image) -> None:
@@ -119,7 +119,7 @@ class PipelineComponent(ABC):
 
     def _pass_datapoint(self, dp: Image) -> None:
         self.dp_manager.datapoint = dp
-        if not self.maybe_filter_func(dp):
+        if not self.filter_func(dp):
             self.serve(dp)
 
 

--- a/deepdoctection/utils/settings.py
+++ b/deepdoctection/utils/settings.py
@@ -101,7 +101,6 @@ class DocumentType(ObjectTypes):
     GOVERNMENT_TENDERS = "government_tenders"
     MANUALS = "manuals"
     PATENTS = "patents"
-    MARK = "mark"
 
 
 @object_types_registry.register("LayoutType")
@@ -132,6 +131,7 @@ class LayoutType(ObjectTypes):
     PAGE_NUMBER = "page_number"
     KEY_VALUE_AREA = "key_value_area"
     LIST_ITEM = "list_item"
+    MARK = "mark"
 
 
 @object_types_registry.register("TableType")

--- a/tests/pipe/test_layout.py
+++ b/tests/pipe/test_layout.py
@@ -22,7 +22,6 @@ Testing module pipe.layout
 from unittest.mock import MagicMock
 
 from pytest import mark
-from sympy.integrals.meijerint_doc import category
 
 from deepdoctection.utils.settings import DocumentType, PageType
 from deepdoctection.datapoint import Image, ImageAnnotation, CategoryAnnotation

--- a/tests/pipe/test_layout.py
+++ b/tests/pipe/test_layout.py
@@ -67,9 +67,9 @@ class TestImageLayoutService:
         assert anns == layout_annotations
 
     @mark.basic
-    def test_pass_datapoint_with_filter_condition(self, dp_image: Image, layout_detect_results: DetectionResult,
-                                                  layout_annotations: ImageAnnotation
-    ) -> None:
+    def test_pass_datapoint_with_filter_condition(self, dp_image: Image,
+                                                  layout_detect_results: DetectionResult) -> None:
+        """Test pass_datapoint with filter condition"""
 
         # Arrange
         def filter_invoices(dp: Image) -> bool:


### PR DESCRIPTION
This PR adds the possibility to dump a processing condition to a pipeline component which then  allows to skip pipeline components based on data point attributes:

```python
self.filter_func
set_inbound_filter(self, filter_func: Callable[[DP], bool])
```

has been added to `PipelineComponent`.