### PR TITLE
V0.39.2 small fixes

### DIFF
--- a/deepdoctection/analyzer/_config.py
+++ b/deepdoctection/analyzer/_config.py
@@ -40,6 +40,7 @@ cfg.TF.CELL.FILTER = None
 cfg.TF.ITEM.WEIGHTS = "item/model-1620000_inf_only.data-00000-of-00001"
 cfg.TF.ITEM.FILTER = None
 
+cfg.PT.ENFORCE_WEIGHTS = False
 cfg.PT.LAYOUT.WEIGHTS = "layout/d2_model_0829999_layout_inf_only.pt"
 cfg.PT.LAYOUT.WEIGHTS_TS = "layout/d2_model_0829999_layout_inf_only.ts"
 cfg.PT.LAYOUT.FILTER = None

--- a/deepdoctection/analyzer/factory.py
+++ b/deepdoctection/analyzer/factory.py
@@ -98,7 +98,8 @@ class ServiceFactory:
         weights = (
             getattr(config.TF, mode).WEIGHTS
             if config.LIB == "TF"
-            else (getattr(config.PT, mode).WEIGHTS if detectron2_available() else getattr(config.PT, mode).WEIGHTS_TS)
+            else (getattr(config.PT, mode).WEIGHTS if detectron2_available() or config.PT.ENFORCE_WEIGHTS
+                  else getattr(config.PT, mode).WEIGHTS_TS)
         )
         filter_categories = (
             getattr(getattr(config.TF, mode), "FILTER")

--- a/deepdoctection/analyzer/factory.py
+++ b/deepdoctection/analyzer/factory.py
@@ -98,8 +98,11 @@ class ServiceFactory:
         weights = (
             getattr(config.TF, mode).WEIGHTS
             if config.LIB == "TF"
-            else (getattr(config.PT, mode).WEIGHTS if detectron2_available() or config.PT.ENFORCE_WEIGHTS
-                  else getattr(config.PT, mode).WEIGHTS_TS)
+            else (
+                getattr(config.PT, mode).WEIGHTS
+                if detectron2_available() or config.PT.ENFORCE_WEIGHTS
+                else getattr(config.PT, mode).WEIGHTS_TS
+            )
         )
         filter_categories = (
             getattr(getattr(config.TF, mode), "FILTER")

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -419,7 +419,7 @@ class Table(Layout):
             filter(lambda c: row_number in (c.row_number, c.row_number + c.row_span - 1), all_cells)  # type: ignore
         )
         row_cells.sort(key=lambda c: c.column_number)  # type: ignore
-        return row_cells
+        return row_cells  # type: ignore
 
     def column(self, column_number: int) -> list[ImageAnnotationBaseView]:
         """
@@ -430,11 +430,11 @@ class Table(Layout):
             category_names=[LayoutType.CELL, CellType.SPANNING], annotation_ids=all_relation_ids
         )
         column_cells = list(
-            filter(lambda c: column_number in (c.column_number, c.column_number + c.column_span - 1), all_cells)
-            # type: ignore
+            filter(lambda c: column_number in  # type: ignore
+                             (c.column_number, c.column_number + c.column_span - 1), all_cells)  # type: ignore
         )
         column_cells.sort(key=lambda c: c.row_number)  # type: ignore
-        return column_cells
+        return column_cells  # type: ignore
 
     @property
     def html(self) -> HTML:

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -416,7 +416,7 @@ class Table(Layout):
             category_names=[LayoutType.CELL, CellType.SPANNING], annotation_ids=all_relation_ids
         )
         row_cells = list(
-            filter(lambda c: row_number in (c.row_number, c.row_number + c.row_span-1), all_cells)  # type: ignore
+            filter(lambda c: row_number in (c.row_number, c.row_number + c.row_span - 1), all_cells)  # type: ignore
         )
         row_cells.sort(key=lambda c: c.column_number)  # type: ignore
         return row_cells
@@ -430,7 +430,7 @@ class Table(Layout):
             category_names=[LayoutType.CELL, CellType.SPANNING], annotation_ids=all_relation_ids
         )
         column_cells = list(
-            filter(lambda c: column_number in (c.column_number, c.column_number + c.column_span-1), all_cells)
+            filter(lambda c: column_number in (c.column_number, c.column_number + c.column_span - 1), all_cells)
             # type: ignore
         )
         column_cells.sort(key=lambda c: c.row_number)  # type: ignore

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -407,6 +407,35 @@ class Table(Layout):
         col_anns = self.base_page.get_annotation(annotation_ids=all_relation_ids, category_names=[LayoutType.COLUMN])
         return col_anns
 
+    def row(self, row_number: int) -> list[ImageAnnotationBaseView]:
+        """
+        Get a list of cells in a row.
+        """
+        all_relation_ids = self.get_relationship(Relationships.CHILD)
+        all_cells = self.base_page.get_annotation(
+            category_names=[LayoutType.CELL, CellType.SPANNING], annotation_ids=all_relation_ids
+        )
+        row_cells = list(
+            filter(lambda c: row_number in (c.row_number, c.row_number + c.row_span-1), all_cells)  # type: ignore
+        )
+        row_cells.sort(key=lambda c: c.column_number)  # type: ignore
+        return row_cells
+
+    def column(self, column_number: int) -> list[ImageAnnotationBaseView]:
+        """
+        Get a list of cells in a column.
+        """
+        all_relation_ids = self.get_relationship(Relationships.CHILD)
+        all_cells = self.base_page.get_annotation(
+            category_names=[LayoutType.CELL, CellType.SPANNING], annotation_ids=all_relation_ids
+        )
+        column_cells = list(
+            filter(lambda c: column_number in (c.column_number, c.column_number + c.column_span-1), all_cells)
+            # type: ignore
+        )
+        column_cells.sort(key=lambda c: c.row_number)  # type: ignore
+        return column_cells
+
     @property
     def html(self) -> HTML:
         """

--- a/deepdoctection/pipe/base.py
+++ b/deepdoctection/pipe/base.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Optional, Union, Callable
+from typing import Any, Callable, Mapping, Optional, Union
 from uuid import uuid1
 
 from ..dataflow import DataFlow, MapData
@@ -100,7 +100,7 @@ class PipelineComponent(ABC):
 
         :param filter_func: A function that takes an image datapoint and returns a boolean value
         """
-        self.filter_func = filter_func # type: ignore
+        self.filter_func = filter_func  # type: ignore
 
     @abstractmethod
     def serve(self, dp: Image) -> None:
@@ -121,7 +121,6 @@ class PipelineComponent(ABC):
         self.dp_manager.datapoint = dp
         if not self.filter_func(dp):
             self.serve(dp)
-
 
     def pass_datapoint(self, dp: Image) -> Image:
         """

--- a/deepdoctection/pipe/common.py
+++ b/deepdoctection/pipe/common.py
@@ -362,7 +362,7 @@ class AnnotationNmsService(PipelineComponent):
             self.threshold = [thresholds for _ in self.nms_pairs]
         else:
             assert len(self.nms_pairs) == len(thresholds), "Sequences of nms_pairs and thresholds must have same length"
-            self.threshold = thresholds # type: ignore
+            self.threshold = thresholds  # type: ignore
         if priority:
             assert len(self.nms_pairs) == len(priority), "Sequences of nms_pairs and priority must have same length"
 

--- a/deepdoctection/pipe/lm.py
+++ b/deepdoctection/pipe/lm.py
@@ -265,7 +265,7 @@ class LMSequenceClassifierService(PipelineComponent):
         padding: Literal["max_length", "do_not_pad", "longest"] = "max_length",
         truncation: bool = True,
         return_overflowing_tokens: bool = False,
-        use_other_as_default_category: bool = False
+        use_other_as_default_category: bool = False,
     ) -> None:
         """
         :param tokenizer: Tokenizer, typing allows currently anything. This will be changed in the future
@@ -309,11 +309,10 @@ class LMSequenceClassifierService(PipelineComponent):
         lm_output = None
         if lm_input is None:
             if self.use_other_as_default_category:
-                class_id = self.language_model.categories.get_categories(as_dict=True,
-                                                                         name_as_key=True).get(TokenClasses.OTHER, 1)
-                lm_output = SequenceClassResult(class_name=TokenClasses.OTHER,
-                                                class_id = class_id,
-                                                score=-1.)
+                class_id = self.language_model.categories.get_categories(as_dict=True, name_as_key=True).get(
+                    TokenClasses.OTHER, 1
+                )
+                lm_output = SequenceClassResult(class_name=TokenClasses.OTHER, class_id=class_id, score=-1.0)
         else:
             lm_output = self.language_model.predict(**lm_input)
         if lm_output:

--- a/deepdoctection/train/hf_layoutlm_train.py
+++ b/deepdoctection/train/hf_layoutlm_train.py
@@ -499,9 +499,7 @@ def train_hf_layoutlm(
         )
         pipeline_component_cls = pipeline_component_registry.get(pipeline_component_name)
         if dataset_type == DatasetType.SEQUENCE_CLASSIFICATION:
-            pipeline_component = pipeline_component_cls(tokenizer_fast,
-                                                        dd_model,
-                                                        use_other_as_default_category=True)
+            pipeline_component = pipeline_component_cls(tokenizer_fast, dd_model, use_other_as_default_category=True)
         else:
             pipeline_component = pipeline_component_cls(
                 tokenizer_fast,

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ _DEPS = [
     "tensorflow-addons>=0.17.1",
     "tf2onnx>=1.9.2",
     "python-doctr==0.8.1",
-    "fasttext==0.9.2",
     "fasttext-wheel",
     # dev dependencies
     "python-dotenv==1.0.0",

--- a/tests/extern/test_fastlang.py
+++ b/tests/extern/test_fastlang.py
@@ -64,7 +64,6 @@ class TestFasttextLangDetector:
         assert result.text == "ita"
         assert result.score == 0.99414486
 
-
     @staticmethod
     @mark.additional
     def test_non_mock_fasttext_lang_detector_predicts_language() -> None:

--- a/tests/pipe/test_layout.py
+++ b/tests/pipe/test_layout.py
@@ -23,10 +23,10 @@ from unittest.mock import MagicMock
 
 from pytest import mark
 
-from deepdoctection.utils.settings import DocumentType, PageType
-from deepdoctection.datapoint import Image, ImageAnnotation, CategoryAnnotation
+from deepdoctection.datapoint import CategoryAnnotation, Image, ImageAnnotation
 from deepdoctection.extern.base import DetectionResult, ObjectDetector
 from deepdoctection.pipe.layout import ImageLayoutService
+from deepdoctection.utils.settings import DocumentType, PageType
 
 
 class TestImageLayoutService:
@@ -67,8 +67,9 @@ class TestImageLayoutService:
         assert anns == layout_annotations
 
     @mark.basic
-    def test_pass_datapoint_with_filter_condition(self, dp_image: Image,
-                                                  layout_detect_results: DetectionResult) -> None:
+    def test_pass_datapoint_with_filter_condition(
+        self, dp_image: Image, layout_detect_results: DetectionResult
+    ) -> None:
         """Test pass_datapoint with filter condition"""
 
         # Arrange
@@ -79,8 +80,9 @@ class TestImageLayoutService:
 
         self._layout_detector.predict = MagicMock(return_value=layout_detect_results)
         self.image_layout_service.set_inbound_filter(filter_invoices)
-        dp_image.summary.dump_sub_category(PageType.DOCUMENT_TYPE,
-                                           CategoryAnnotation(category_name= DocumentType.INVOICE))
+        dp_image.summary.dump_sub_category(
+            PageType.DOCUMENT_TYPE, CategoryAnnotation(category_name=DocumentType.INVOICE)
+        )
 
         # Act
         dp = self.image_layout_service.pass_datapoint(dp_image)


### PR DESCRIPTION
This PR add a new argument `PT.ENFORCE_WEIGHTS` so that one can use table transformer if detectron2 is not installed.

It also adds two methods 'row(row_number)` and `column(column_number)` to get all cells with a given row number, column number, resp. 