### PR TITLE
Fix issue #408

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -35,7 +35,6 @@ filelock==3.8.2
     #   huggingface-hub
     #   torch
     #   transformers
-    #   triton
 fsspec==2023.12.2
     # via
     #   huggingface-hub
@@ -132,37 +131,6 @@ numpy==1.24.0
     #   scipy
     #   tensorpack
     #   transformers
-nvidia-cublas-cu12==12.1.3.1
-    # via
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cuda-cupti-cu12==12.1.105
-    # via torch
-nvidia-cuda-nvrtc-cu12==12.1.105
-    # via torch
-nvidia-cuda-runtime-cu12==12.1.105
-    # via torch
-nvidia-cudnn-cu12==8.9.2.26
-    # via torch
-nvidia-cufft-cu12==11.0.2.54
-    # via torch
-nvidia-curand-cu12==10.3.2.106
-    # via torch
-nvidia-cusolver-cu12==11.4.5.107
-    # via torch
-nvidia-cusparse-cu12==12.1.0.106
-    # via
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-nccl-cu12==2.18.1
-    # via torch
-nvidia-nvjitlink-cu12==12.3.101
-    # via
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
-nvidia-nvtx-cu12==12.1.105
-    # via torch
 opencv-python-headless==4.9.0.80
     # via jdeskew
 packaging==21.3
@@ -261,8 +229,6 @@ tqdm==4.64.0
     #   transformers
 transformers==4.48.3
     # via deepdoctection (setup.py)
-triton==2.1.0
-    # via torch
 typing-extensions==4.4.0
     # via
     #   huggingface-hub

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ _DEPS = [
     "scipy>=1.13.1",
     "termcolor>=1.1",
     "tabulate>=0.7.7",
-    "tqdm==4.64.0",
+    "tqdm>=4.64.0",
     # type-stubs
     "types-PyYAML>=6.0.12.12",
     "types-termcolor>=1.1.3",


### PR DESCRIPTION
This PR unpins the version of `tqdm`. Everything above 4.68.0 is accepted.