### PR TITLE
V.0.43.3 small fixes

### DIFF
--- a/deepdoctection/__init__.py
+++ b/deepdoctection/__init__.py
@@ -25,7 +25,7 @@ from .utils.logger import LoggingRecord, logger
 
 # pylint: enable=wrong-import-position
 
-__version__ = "0.43.2"
+__version__ = "0.43.3"
 
 _IMPORT_STRUCTURE = {
     "analyzer": ["config_sanity_checks", "get_dd_analyzer", "ServiceFactory"],

--- a/deepdoctection/datapoint/image.py
+++ b/deepdoctection/datapoint/image.py
@@ -479,8 +479,8 @@ class Image:
 
     def remove(
         self,
-        annotation_ids: Optional[Union[str, list[str]]] = None,
-        service_ids: Optional[Union[str, list[str]]] = None,
+        annotation_ids: Optional[Union[str, Sequence[str]]] = None,
+        service_ids: Optional[Union[str, Sequence[str]]] = None,
     ) -> None:
         """
         Instead of removing consider deactivating annotations.

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -1390,19 +1390,32 @@ class Page(Image):
             include_residual_text_container=include_residual_text_container,
         )
 
-    def get_token(self) -> list[Mapping[str, str]]:
+    def get_entities(self) -> list[Mapping[str, str]]:
         """
         Returns:
-             A list of tuples with word and non default token tags
+             A list of dicts with the following structure:
+
+            ```python
+            {
+                "word": str,  # word characters
+                "entity": str, # token tag
+                "annotation_id": str, # annotation id of the word
+                "successor_annotation_id": Optional[str] # annotation_id of the successor word, if any
+            }
+            ```
+
         """
         block_with_order = self._order("layouts")
         all_words = []
         for block in block_with_order:
             all_words.extend(block.get_ordered_words())  # type: ignore
         return [
-            {"word": word.CHARACTERS, "entity": word.TOKEN_TAG}
+            {"word": word.characters,
+             "entity": word.token_tag.value,
+             "annotation_id": word.annotation_id,
+             "successor_annotation_id": word.successor[0].annotation_id if word.successor else None}
             for word in all_words
-            if word.TOKEN_TAG not in (TokenClasses.OTHER, None)
+            if word.token_tag not in (TokenClasses.OTHER, None)
         ]
 
     def __copy__(self) -> Page:

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -183,7 +183,7 @@ class Word(ImageAnnotationBaseView):
         attr_names = (
             set(WordType)
             .union(super().get_attribute_names())
-            .union({Relationships.READING_ORDER, Relationships.LAYOUT_LINK})
+            .union({Relationships.READING_ORDER, Relationships.LAYOUT_LINK, Relationships.LINK})
         )
         return {attr_name.value if isinstance(attr_name, ObjectTypes) else attr_name for attr_name in attr_names}
 

--- a/deepdoctection/extern/base.py
+++ b/deepdoctection/extern/base.py
@@ -502,6 +502,7 @@ class TokenClassResult:
        semantic_name: semantic name
        bio_tag: bio tag
        score: prediction score
+       successor_uuid: uuid of the next token in the sequence
     """
 
     uuid: str
@@ -512,6 +513,7 @@ class TokenClassResult:
     bio_tag: ObjectTypes = DefaultType.DEFAULT_TYPE
     score: Optional[float] = None
     token_id: Optional[int] = None
+    successor_uuid: Optional[str] = None
 
 
 @dataclass

--- a/deepdoctection/mapper/xfundstruct.py
+++ b/deepdoctection/mapper/xfundstruct.py
@@ -200,7 +200,7 @@ def xfund_to_image(
                 ann_ids.extend(entity_id_to_ann_id[linked_entity])
             for ann_id in ann_ids:
                 if ann_id != word.annotation_id:
-                    word.dump_relationship(Relationships.SEMANTIC_ENTITY_LINK, ann_id)
+                    word.dump_relationship(Relationships.LINK, ann_id)
 
     if mapping_context.context_error:
         return None

--- a/deepdoctection/pipe/anngen.py
+++ b/deepdoctection/pipe/anngen.py
@@ -19,7 +19,7 @@
 Datapoint manager
 """
 from dataclasses import asdict
-from typing import Optional, Union
+from typing import Optional, Union, Sequence
 
 import numpy as np
 
@@ -371,6 +371,19 @@ class DatapointManager:
         if annotation_context.context_error:
             return None
         return ann.annotation_id
+
+    def remove_annotations(self, annotation_ids: Sequence[str]) -> None:
+        """
+        Removes the annotation by the given `annotation_id`.
+
+        Args:
+            annotation_ids: The `annotation_id` to remove.
+        """
+        self.assert_datapoint_passed()
+        self.datapoint.remove(annotation_ids)
+        for ann_id in annotation_ids:
+            if ann_id in self._cache_anns:
+                self._cache_anns.pop(ann_id)
 
     def deactivate_annotation(self, annotation_id: str) -> None:
         """

--- a/deepdoctection/utils/settings.py
+++ b/deepdoctection/utils/settings.py
@@ -231,6 +231,7 @@ class Relationships(ObjectTypes):
     READING_ORDER = "reading_order"
     LINK = "link"
     LAYOUT_LINK = "layout_link"
+    SUCCESSOR = "successor"
 
 
 @object_types_registry.register("Languages")

--- a/deepdoctection/utils/settings.py
+++ b/deepdoctection/utils/settings.py
@@ -229,7 +229,7 @@ class Relationships(ObjectTypes):
 
     CHILD = "child"
     READING_ORDER = "reading_order"
-    SEMANTIC_ENTITY_LINK = "semantic_entity_link"
+    LINK = "link"
     LAYOUT_LINK = "layout_link"
 
 


### PR DESCRIPTION
This PR:

- replaces `Page.get_token` with `Page.get_entities`,
- renames `Relationship.SEMANTIC_ENTITY_LINK` with `Relationship.LINK`,
- adding `successor_uuid` to `TokenClassResults`,
- adding `remove_annotations` to `DataPointManager`, 