### PR TITLE
Version 0.46

### DIFF
--- a/deepdoctection/__init__.py
+++ b/deepdoctection/__init__.py
@@ -25,7 +25,7 @@ from .utils.logger import LoggingRecord, logger
 
 # pylint: enable=wrong-import-position
 
-__version__ = "0.45.1"
+__version__ = "0.46"
 
 _IMPORT_STRUCTURE = {
     "analyzer": ["config_sanity_checks", "get_dd_analyzer", "ServiceFactory", "update_cfg_from_defaults"],

--- a/deepdoctection/__init__.py
+++ b/deepdoctection/__init__.py
@@ -271,6 +271,7 @@ _IMPORT_STRUCTURE = {
         "MultiThreadPipelineComponent",
         "DoctectionPipe",
         "LanguageDetectionService",
+        "skip_if_category_or_service_extracted",
         "ImageLayoutService",
         "LMTokenClassifierService",
         "LMSequenceClassifierService",

--- a/deepdoctection/__init__.py
+++ b/deepdoctection/__init__.py
@@ -25,7 +25,7 @@ from .utils.logger import LoggingRecord, logger
 
 # pylint: enable=wrong-import-position
 
-__version__ = "0.45.0"
+__version__ = "0.45.1"
 
 _IMPORT_STRUCTURE = {
     "analyzer": ["config_sanity_checks", "get_dd_analyzer", "ServiceFactory", "update_cfg_from_defaults"],
@@ -310,12 +310,14 @@ _IMPORT_STRUCTURE = {
         "get_tensorpack_requirement",
         "pytorch_available",
         "get_pytorch_requirement",
+        "pyzmq_available",
         "lxml_available",
         "get_lxml_requirement",
         "apted_available",
         "get_apted_requirement",
         "distance_available",
         "get_distance_requirement",
+        "networkx_available",
         "numpy_v1_available",
         "get_numpy_v1_requirement",
         "transformers_available",

--- a/deepdoctection/analyzer/config.py
+++ b/deepdoctection/analyzer/config.py
@@ -526,6 +526,9 @@ cfg.USE_LM_SEQUENCE_CLASS = False
 # Enables a token classification pipeline component, e.g. a LayoutLM or Bert-like model
 cfg.USE_LM_TOKEN_CLASS = False
 
+# Specifies the selection of the rotation model. There are two models available: A rotation estimator
+# based on Tesseract ('tesseract'), and a rotation estimator based on DocTr ('doctr').
+cfg.ROTATOR.MODEL = "tesseract"
 
 # Relevant when LIB = TF. Specifies the layout detection model.
 # This model should detect multiple or single objects across an entire page.

--- a/deepdoctection/datapoint/box.py
+++ b/deepdoctection/datapoint/box.py
@@ -505,10 +505,10 @@ class BoundingBox:
             if self.absolute_coords:
                 transformed_box = BoundingBox(
                     absolute_coords=not self.absolute_coords,
-                    ulx=min(max(self.ulx / image_width, 0.0),1.0),
-                    uly=min(max(self.uly / image_height, 0.0),1.0),
-                    lrx=max(min(self.lrx / image_width, 1.0),0.0),
-                    lry=max(min(self.lry / image_height, 1.0),0.0),
+                    ulx=min(max(self.ulx / image_width, 0.0), 1.0),
+                    uly=min(max(self.uly / image_height, 0.0), 1.0),
+                    lrx=max(min(self.lrx / image_width, 1.0), 0.0),
+                    lry=max(min(self.lry / image_height, 1.0), 0.0),
                 )
             else:
                 transformed_box = BoundingBox(

--- a/deepdoctection/datapoint/box.py
+++ b/deepdoctection/datapoint/box.py
@@ -284,7 +284,7 @@ class BoundingBox:
             raise BoundingBoxError(
                 f"bounding box must have height and width >0. Check coords "
                 f"ulx: {self.ulx}, uly: {self.uly}, lrx: {self.lrx}, "
-                f"lry: {self.lry}."
+                f"lry: {self.lry}, absolute_coords: {self.absolute_coords}"
             )
         if not self.absolute_coords and not (
             0 <= self.ulx <= 1 and 0 <= self.uly <= 1 and 0 <= self.lrx <= 1 and 0 <= self.lry <= 1
@@ -505,10 +505,10 @@ class BoundingBox:
             if self.absolute_coords:
                 transformed_box = BoundingBox(
                     absolute_coords=not self.absolute_coords,
-                    ulx=max(self.ulx / image_width, 0.0),
-                    uly=max(self.uly / image_height, 0.0),
-                    lrx=min(self.lrx / image_width, 1.0),
-                    lry=min(self.lry / image_height, 1.0),
+                    ulx=min(max(self.ulx / image_width, 0.0),1.0),
+                    uly=min(max(self.uly / image_height, 0.0),1.0),
+                    lrx=max(min(self.lrx / image_width, 1.0),0.0),
+                    lry=max(min(self.lry / image_height, 1.0),0.0),
                 )
             else:
                 transformed_box = BoundingBox(

--- a/deepdoctection/datapoint/image.py
+++ b/deepdoctection/datapoint/image.py
@@ -318,7 +318,7 @@ class Image:
         return _Img(self.image)
 
     @property
-    def width(self) -> float:
+    def width(self) -> int:
         """
         `width`
         """
@@ -327,7 +327,7 @@ class Image:
         return self._bbox.width
 
     @property
-    def height(self) -> float:
+    def height(self) -> int:
         """
         `height`
         """
@@ -335,7 +335,7 @@ class Image:
             raise ImageError("Height not available. Call set_width_height first")
         return self._bbox.height
 
-    def set_width_height(self, width: float, height: float) -> None:
+    def set_width_height(self, width: int, height: int) -> None:
         """
         Defines bounding box of the image if not already set. Use this, if you do not want to keep the image separated
         for memory reasons.
@@ -345,7 +345,7 @@ class Image:
             height: height of image
         """
         if self._bbox is None:
-            self._bbox = BoundingBox(ulx=0.0, uly=0.0, height=height, width=width, absolute_coords=True)
+            self._bbox = BoundingBox(ulx=0, uly=0, height=height, width=width, absolute_coords=True)
             self._self_embedding()
 
     def set_embedding(self, image_id: str, bounding_box: BoundingBox) -> None:

--- a/deepdoctection/datapoint/image.py
+++ b/deepdoctection/datapoint/image.py
@@ -36,7 +36,7 @@ from ..utils.logger import LoggingRecord, logger
 from ..utils.settings import ObjectTypes, SummaryType, get_type
 from ..utils.types import ImageDict, PathLikeOrStr, PixelValues
 from .annotation import Annotation, AnnotationMap, BoundingBox, CategoryAnnotation, ImageAnnotation
-from .box import crop_box_from_image, global_to_local_coords, intersection_box, BoxCoordinate
+from .box import BoxCoordinate, crop_box_from_image, global_to_local_coords, intersection_box
 from .convert import as_dict, convert_b64_to_np_array, convert_np_array_to_b64, convert_pdf_bytes_to_np_array_v2
 
 

--- a/deepdoctection/datapoint/image.py
+++ b/deepdoctection/datapoint/image.py
@@ -36,7 +36,7 @@ from ..utils.logger import LoggingRecord, logger
 from ..utils.settings import ObjectTypes, SummaryType, get_type
 from ..utils.types import ImageDict, PathLikeOrStr, PixelValues
 from .annotation import Annotation, AnnotationMap, BoundingBox, CategoryAnnotation, ImageAnnotation
-from .box import crop_box_from_image, global_to_local_coords, intersection_box
+from .box import crop_box_from_image, global_to_local_coords, intersection_box, BoxCoordinate
 from .convert import as_dict, convert_b64_to_np_array, convert_np_array_to_b64, convert_pdf_bytes_to_np_array_v2
 
 
@@ -318,7 +318,7 @@ class Image:
         return _Img(self.image)
 
     @property
-    def width(self) -> int:
+    def width(self) -> BoxCoordinate:
         """
         `width`
         """
@@ -327,7 +327,7 @@ class Image:
         return self._bbox.width
 
     @property
-    def height(self) -> int:
+    def height(self) -> BoxCoordinate:
         """
         `height`
         """
@@ -335,7 +335,7 @@ class Image:
             raise ImageError("Height not available. Call set_width_height first")
         return self._bbox.height
 
-    def set_width_height(self, width: int, height: int) -> None:
+    def set_width_height(self, width: BoxCoordinate, height: BoxCoordinate) -> None:
         """
         Defines bounding box of the image if not already set. Use this, if you do not want to keep the image separated
         for memory reasons.

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -428,6 +428,8 @@ class List(Layout):
             A list of words order by reading order. Words with no `reading_order` will not be returned"""
         try:
             list_items = self.list_items
+            if not list_items:
+                return super().get_ordered_words()
             all_words = []
             list_items.sort(key=lambda x: x.bbox[1])
             for list_item in list_items:
@@ -755,6 +757,8 @@ class Table(Layout):
         """
         try:
             cells = self.cells
+            if not cells:
+                return super().get_ordered_words()
             all_words = []
             cells.sort(key=lambda x: (x.ROW_NUMBER, x.COLUMN_NUMBER))
             for cell in cells:

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -1058,6 +1058,8 @@ class Page(Image):
         Returns:
             A `Page` instance with all annotations as `ImageAnnotationBaseView` subclasses.
         """
+        if isinstance(image_orig, Page):
+            raise ImageError("Page.from_image() cannot be called on a Page instance.")
 
         if text_container is None:
             text_container = IMAGE_DEFAULTS.TEXT_CONTAINER

--- a/deepdoctection/datapoint/view.py
+++ b/deepdoctection/datapoint/view.py
@@ -1316,7 +1316,7 @@ class Page(Image):
             If `interactive=False` will return a `np.array`.
         """
 
-        category_names_list: list[Union[str, None]] = []
+        category_names_list: list[Tuple[Union[str, None], Union[str, None]]] = []
         box_stack = []
         cells_found = False
 
@@ -1329,22 +1329,23 @@ class Page(Image):
             anns = self.get_annotation(category_names=list(debug_kwargs.keys()))
             for ann in anns:
                 box_stack.append(self._ann_viz_bbox(ann))
-                category_names_list.append(str(getattr(ann, debug_kwargs[ann.category_name])))
+                val = str(getattr(ann, debug_kwargs[ann.category_name]))
+                category_names_list.append((val, val))
 
         if show_layouts and not debug_kwargs:
             for item in self.layouts:
                 box_stack.append(self._ann_viz_bbox(item))
-                category_names_list.append(item.category_name.value)
+                category_names_list.append((item.category_name.value, item.category_name.value))
 
         if show_figures and not debug_kwargs:
             for item in self.figures:
                 box_stack.append(self._ann_viz_bbox(item))
-                category_names_list.append(item.category_name.value)
+                category_names_list.append((item.category_name.value, item.category_name.value))
 
         if show_tables and not debug_kwargs:
             for table in self.tables:
                 box_stack.append(self._ann_viz_bbox(table))
-                category_names_list.append(LayoutType.TABLE.value)
+                category_names_list.append((LayoutType.TABLE.value, LayoutType.TABLE.value))
                 if show_cells:
                     for cell in table.cells:
                         if cell.category_name in {
@@ -1353,21 +1354,21 @@ class Page(Image):
                         }:
                             cells_found = True
                             box_stack.append(self._ann_viz_bbox(cell))
-                            category_names_list.append(None)
+                            category_names_list.append((None, cell.category_name.value))
                 if show_table_structure:
                     rows = table.rows
                     cols = table.columns
                     for row in rows:
                         box_stack.append(self._ann_viz_bbox(row))
-                        category_names_list.append(None)
+                        category_names_list.append((None, row.category_name.value))
                     for col in cols:
                         box_stack.append(self._ann_viz_bbox(col))
-                        category_names_list.append(None)
+                        category_names_list.append((None, col.category_name.value))
 
         if show_cells and not cells_found and not debug_kwargs:
             for ann in self.get_annotation(category_names=[LayoutType.CELL, CellType.SPANNING]):
                 box_stack.append(self._ann_viz_bbox(ann))
-                category_names_list.append(None)
+                category_names_list.append((None, ann.category_name.value))
 
         if show_words and not debug_kwargs:
             all_words = []
@@ -1385,22 +1386,36 @@ class Page(Image):
                 for word in all_words:
                     box_stack.append(self._ann_viz_bbox(word))
                     if show_token_class:
-                        category_names_list.append(word.token_class.value if word.token_class is not None else None)
+                        category_names_list.append(
+                            (word.token_class.value, word.token_class.value)
+                            if word.token_class is not None
+                            else (None, None)
+                        )
                     else:
-                        category_names_list.append(word.token_tag.value if word.token_tag is not None else None)
+                        category_names_list.append(
+                            (word.token_tag.value, word.token_tag.value) if word.token_tag is not None else (None, None)
+                        )
             else:
                 for word in all_words:
                     if word.token_class is not None and word.token_class != TokenClasses.OTHER:
                         box_stack.append(self._ann_viz_bbox(word))
                         if show_token_class:
-                            category_names_list.append(word.token_class.value if word.token_class is not None else None)
+                            category_names_list.append(
+                                (word.token_class.value, word.token_class.value)
+                                if word.token_class is not None
+                                else (None, None)
+                            )
                         else:
-                            category_names_list.append(word.token_tag.value if word.token_tag is not None else None)
+                            category_names_list.append(
+                                (word.token_tag.value, word.token_tag.value)
+                                if word.token_tag is not None
+                                else (None, None)
+                            )
 
         if show_residual_layouts and not debug_kwargs:
             for item in self.residual_layouts:
                 box_stack.append(item.bbox)
-                category_names_list.append(item.category_name.value)
+                category_names_list.append((item.category_name.value, item.category_name.value))
 
         if self.image is not None:
             scale_fx = scaled_width / self.width

--- a/deepdoctection/eval/cocometric.py
+++ b/deepdoctection/eval/cocometric.py
@@ -275,6 +275,7 @@ class CocoMetric(MetricBase):
                       get the ultimate F1-score.
             f1_iou: Use with `f1_score=True` and reset the f1 iou threshold
                     per_category: Whether to calculate metrics per category
+            per_category: If set to True, f1 score will be returned by each category.
         """
         if max_detections is not None:
             assert len(max_detections) == 3, max_detections

--- a/deepdoctection/extern/base.py
+++ b/deepdoctection/extern/base.py
@@ -263,7 +263,7 @@ class PredictorBase(ABC):
         requirements = cls.get_requirements()
         name = cls.__name__ if hasattr(cls, "__name__") else cls.__class__.__name__
         if not all(requirement[1] for requirement in requirements):
-            raise ImportError(
+            raise ModuleNotFoundError(
                 "\n".join(
                     [f"{name} has the following dependencies:"]
                     + [requirement[2] for requirement in requirements if not requirement[1]]

--- a/deepdoctection/extern/base.py
+++ b/deepdoctection/extern/base.py
@@ -353,8 +353,8 @@ class DetectionResult:
     uuid: Optional[str] = None
     relationships: Optional[dict[str, Any]] = None
     angle: Optional[float] = None
-    image_width: Optional[int] = None
-    image_height: Optional[int] = None
+    image_width: Optional[Union[int, float]] = None
+    image_height: Optional[Union[int, float]] = None
 
 
 class ObjectDetector(PredictorBase, ABC):

--- a/deepdoctection/extern/base.py
+++ b/deepdoctection/extern/base.py
@@ -334,6 +334,11 @@ class DetectionResult:
         block: block number. For reading order from some ocr predictors
         line: line number. For reading order from some ocr predictors
         uuid: uuid. For assigning detection result (e.g. text to image annotations)
+        relationships: A dictionary of relationships. Each key is a relationship type and each value is a list of
+                       uuids of the related annotations.
+        angle: angle of rotation in degrees. Only used for text detection.
+        image_width: image width
+        image_height: image height
     """
 
     box: Optional[list[float]] = None
@@ -348,6 +353,8 @@ class DetectionResult:
     uuid: Optional[str] = None
     relationships: Optional[dict[str, Any]] = None
     angle: Optional[float] = None
+    image_width: Optional[int] = None
+    image_height: Optional[int] = None
 
 
 class ObjectDetector(PredictorBase, ABC):

--- a/deepdoctection/extern/doctrocr.py
+++ b/deepdoctection/extern/doctrocr.py
@@ -586,8 +586,8 @@ class DocTrRotationTransformer(ImageTransformer):
         if detect_results:
             if detect_results[0].angle:
                 self.rotator.set_angle(detect_results[0].angle)  # type: ignore
-                self.rotator.set_image_width(detect_results[0].image_width) # type: ignore
-                self.rotator.set_image_height(detect_results[0].image_height) # type: ignore
+                self.rotator.set_image_width(detect_results[0].image_width)  # type: ignore
+                self.rotator.set_image_height(detect_results[0].image_height)  # type: ignore
                 transformed_coords = self.rotator.apply_coords(
                     np.asarray([detect_result.box for detect_result in detect_results], dtype=float)
                 )

--- a/deepdoctection/extern/hflayoutlm.py
+++ b/deepdoctection/extern/hflayoutlm.py
@@ -1024,12 +1024,9 @@ class HFLayoutLmv2SequenceClassifier(HFLayoutLmSequenceClassifierBase):
         else:
             raise ValueError(f"images must be list but is {type(images)}")
 
-        result = predict_sequence_classes_from_layoutlm(input_ids,
-                                                        attention_mask,
-                                                        token_type_ids,
-                                                        boxes,
-                                                        self.model,
-                                                        images)
+        result = predict_sequence_classes_from_layoutlm(
+            input_ids, attention_mask, token_type_ids, boxes, self.model, images
+        )
 
         result.class_id += 1
         result.class_name = self.categories.categories[result.class_id]
@@ -1123,12 +1120,9 @@ class HFLayoutLmv3SequenceClassifier(HFLayoutLmSequenceClassifierBase):
         else:
             raise ValueError(f"images must be list but is {type(images)}")
 
-        result = predict_sequence_classes_from_layoutlm(input_ids,
-                                                        attention_mask,
-                                                        token_type_ids,
-                                                        boxes,
-                                                        self.model,
-                                                        images)
+        result = predict_sequence_classes_from_layoutlm(
+            input_ids, attention_mask, token_type_ids, boxes, self.model, images
+        )
 
         result.class_id += 1
         result.class_name = self.categories.categories[result.class_id]

--- a/deepdoctection/extern/tessocr.py
+++ b/deepdoctection/extern/tessocr.py
@@ -470,7 +470,7 @@ class TesseractRotationTransformer(ImageTransformer):
     def transform_coords(self, detect_results: Sequence[DetectionResult]) -> Sequence[DetectionResult]:
         if detect_results:
             if detect_results[0].angle:
-                rotator = RotationTransform(detect_results[0].angle)
+                rotator = RotationTransform(detect_results[0].angle)  # type: ignore
                 rotator.image_width = detect_results[0].image_width
                 rotator.image_height = detect_results[0].image_height
                 transformed_coords = rotator.apply_coords(np.asarray([detect_result.box for detect_result

--- a/deepdoctection/extern/tessocr.py
+++ b/deepdoctection/extern/tessocr.py
@@ -28,10 +28,10 @@ from errno import ENOENT
 from itertools import groupby
 from os import environ, fspath
 from pathlib import Path
-from typing import Any, Mapping, Optional, Union, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
-from packaging.version import InvalidVersion, Version, parse
 import numpy as np
+from packaging.version import InvalidVersion, Version, parse
 
 from ..utils.context import save_tmp_file, timeout_manager
 from ..utils.error import DependencyError, TesseractError
@@ -452,6 +452,7 @@ class TesseractRotationTransformer(ImageTransformer):
         self.name = fspath(_TESS_PATH) + "-rotation"
         self.categories = ModelCategories(init_categories={1: PageType.ANGLE})
         self.model_id = self.get_model_id()
+        self.rotator = RotationTransform(360)
 
     def transform_image(self, np_img: PixelValues, specification: DetectionResult) -> PixelValues:
         """
@@ -470,15 +471,15 @@ class TesseractRotationTransformer(ImageTransformer):
     def transform_coords(self, detect_results: Sequence[DetectionResult]) -> Sequence[DetectionResult]:
         if detect_results:
             if detect_results[0].angle:
-                rotator = RotationTransform(detect_results[0].angle)  # type: ignore
-                rotator.image_width = detect_results[0].image_width
-                rotator.image_height = detect_results[0].image_height
-                transformed_coords = rotator.apply_coords(np.asarray([detect_result.box for detect_result
-                                                 in detect_results], dtype=float))
+                self.rotator.set_angle(detect_results[0].angle)  # type: ignore
+                self.rotator.set_image_width(detect_results[0].image_width) # type: ignore
+                self.rotator.set_image_height(detect_results[0].image_height) # type: ignore
+                transformed_coords = self.rotator.apply_coords(
+                    np.asarray([detect_result.box for detect_result in detect_results], dtype=float)
+                )
                 for idx, detect_result in enumerate(detect_results):
                     detect_result.box = transformed_coords[idx, :].tolist()
         return detect_results
-
 
     def predict(self, np_img: PixelValues) -> DetectionResult:
         """

--- a/deepdoctection/extern/tessocr.py
+++ b/deepdoctection/extern/tessocr.py
@@ -472,8 +472,8 @@ class TesseractRotationTransformer(ImageTransformer):
         if detect_results:
             if detect_results[0].angle:
                 self.rotator.set_angle(detect_results[0].angle)  # type: ignore
-                self.rotator.set_image_width(detect_results[0].image_width) # type: ignore
-                self.rotator.set_image_height(detect_results[0].image_height) # type: ignore
+                self.rotator.set_image_width(detect_results[0].image_width)  # type: ignore
+                self.rotator.set_image_height(detect_results[0].image_height)  # type: ignore
                 transformed_coords = self.rotator.apply_coords(
                     np.asarray([detect_result.box for detect_result in detect_results], dtype=float)
                 )

--- a/deepdoctection/pipe/order.py
+++ b/deepdoctection/pipe/order.py
@@ -309,8 +309,9 @@ class OrderGenerator:
         filtered_blocks: Sequence[tuple[int, str]]
         for idx in range(max_block_number + 1):
             filtered_blocks = list(filter(lambda x: x[0] == idx, blocks))  # type: ignore # pylint: disable=W0640
-            sorted_blocks.extend(self._sort_anns_grouped_by_blocks(filtered_blocks, anns, image_width, image_height,
-                                                                   image_id))
+            sorted_blocks.extend(
+                self._sort_anns_grouped_by_blocks(filtered_blocks, anns, image_width, image_height, image_id)
+            )
         reading_blocks = [(idx + 1, block[1]) for idx, block in enumerate(sorted_blocks)]
 
         if logger.isEnabledFor(DEBUG):
@@ -351,7 +352,7 @@ class OrderGenerator:
         anns: Sequence[ImageAnnotation],
         image_width: float,
         image_height: float,
-        image_id: Optional[str] = None
+        image_id: Optional[str] = None,
     ) -> list[tuple[int, str]]:
         if not block:
             return []

--- a/deepdoctection/pipe/order.py
+++ b/deepdoctection/pipe/order.py
@@ -228,8 +228,8 @@ class OrderGenerator:
         columns: list[BoundingBox] = []
         anns.sort(
             key=lambda x: (
-                x.bounding_box.transform(image_width, image_height).cy,  # type: ignore
-                x.bounding_box.transform(image_width, image_height).cx,  # type: ignore
+                x.get_bounding_box(image_id).transform(image_width, image_height).cy,  # type: ignore
+                x.get_bounding_box(image_id).transform(image_width, image_height).cx,  # type: ignore
             )
         )
         for ann in anns:
@@ -309,7 +309,7 @@ class OrderGenerator:
         filtered_blocks: Sequence[tuple[int, str]]
         for idx in range(max_block_number + 1):
             filtered_blocks = list(filter(lambda x: x[0] == idx, blocks))  # type: ignore # pylint: disable=W0640
-            sorted_blocks.extend(self._sort_anns_grouped_by_blocks(filtered_blocks, anns, image_width, image_height))
+            sorted_blocks.extend(self._sort_anns_grouped_by_blocks(filtered_blocks, anns, image_width, image_height, image_id))
         reading_blocks = [(idx + 1, block[1]) for idx, block in enumerate(sorted_blocks)]
 
         if logger.isEnabledFor(DEBUG):
@@ -346,7 +346,11 @@ class OrderGenerator:
 
     @staticmethod
     def _sort_anns_grouped_by_blocks(
-        block: Sequence[tuple[int, str]], anns: Sequence[ImageAnnotation], image_width: float, image_height: float
+        block: Sequence[tuple[int, str]],
+        anns: Sequence[ImageAnnotation],
+        image_width: float,
+        image_height: float,
+        image_id: Optional[str] = None
     ) -> list[tuple[int, str]]:
         if not block:
             return []
@@ -356,8 +360,8 @@ class OrderGenerator:
         block_anns = [ann for ann in anns if ann.annotation_id in ann_ids]
         block_anns.sort(
             key=lambda x: (
-                round(x.bounding_box.transform(image_width, image_height).uly, 2),  # type: ignore
-                round(x.bounding_box.transform(image_width, image_height).ulx, 2),  # type: ignore
+                round(x.get_bounding_box(image_id).transform(image_width, image_height).uly, 2),  # type: ignore
+                round(x.get_bounding_box(image_id).transform(image_width, image_height).ulx, 2),  # type: ignore
             )
         )
         return [(block_number, ann.annotation_id) for ann in block_anns]

--- a/deepdoctection/pipe/order.py
+++ b/deepdoctection/pipe/order.py
@@ -228,8 +228,8 @@ class OrderGenerator:
         columns: list[BoundingBox] = []
         anns.sort(
             key=lambda x: (
-                x.get_bounding_box(image_id).transform(image_width, image_height).cy,  # type: ignore
-                x.get_bounding_box(image_id).transform(image_width, image_height).cx,  # type: ignore
+                x.get_bounding_box(image_id).transform(image_width, image_height).cy,
+                x.get_bounding_box(image_id).transform(image_width, image_height).cx,
             )
         )
         for ann in anns:
@@ -309,7 +309,8 @@ class OrderGenerator:
         filtered_blocks: Sequence[tuple[int, str]]
         for idx in range(max_block_number + 1):
             filtered_blocks = list(filter(lambda x: x[0] == idx, blocks))  # type: ignore # pylint: disable=W0640
-            sorted_blocks.extend(self._sort_anns_grouped_by_blocks(filtered_blocks, anns, image_width, image_height, image_id))
+            sorted_blocks.extend(self._sort_anns_grouped_by_blocks(filtered_blocks, anns, image_width, image_height,
+                                                                   image_id))
         reading_blocks = [(idx + 1, block[1]) for idx, block in enumerate(sorted_blocks)]
 
         if logger.isEnabledFor(DEBUG):
@@ -360,8 +361,8 @@ class OrderGenerator:
         block_anns = [ann for ann in anns if ann.annotation_id in ann_ids]
         block_anns.sort(
             key=lambda x: (
-                round(x.get_bounding_box(image_id).transform(image_width, image_height).uly, 2),  # type: ignore
-                round(x.get_bounding_box(image_id).transform(image_width, image_height).ulx, 2),  # type: ignore
+                round(x.get_bounding_box(image_id).transform(image_width, image_height).uly, 2),
+                round(x.get_bounding_box(image_id).transform(image_width, image_height).ulx, 2),
             )
         )
         return [(block_number, ann.annotation_id) for ann in block_anns]

--- a/deepdoctection/pipe/refine.py
+++ b/deepdoctection/pipe/refine.py
@@ -27,7 +27,7 @@ from dataclasses import asdict
 from itertools import chain, product
 from typing import DefaultDict, Optional, Sequence, Union
 
-import networkx as nx  # type: ignore
+from lazy_imports import try_import
 
 from ..datapoint.annotation import ImageAnnotation
 from ..datapoint.box import merge_boxes
@@ -35,9 +35,14 @@ from ..datapoint.image import Image, MetaAnnotation
 from ..extern.base import DetectionResult
 from ..mapper.maputils import MappingContextManager
 from ..utils.error import ImageError
+from ..utils.file_utils import networkx_available
 from ..utils.settings import CellType, LayoutType, ObjectTypes, Relationships, TableType, get_type
 from .base import PipelineComponent
 from .registry import pipeline_component_registry
+
+with try_import() as import_guard:
+    import networkx as nx  # type: ignore
+
 
 __all__ = ["TableSegmentationRefinementService", "generate_html_string"]
 
@@ -441,6 +446,10 @@ class TableSegmentationRefinementService(PipelineComponent):
             table_names: Sequence of table object types.
             cell_names: Sequence of cell object types.
         """
+        if not networkx_available():
+            raise ModuleNotFoundError(
+                "TableSegmentationRefinementService requires networkx." "Please install separately."
+            )
         self.table_name = table_names
         self.cell_names = cell_names
         super().__init__("table_segment_refine")

--- a/deepdoctection/pipe/refine.py
+++ b/deepdoctection/pipe/refine.py
@@ -448,7 +448,7 @@ class TableSegmentationRefinementService(PipelineComponent):
         """
         if not networkx_available():
             raise ModuleNotFoundError(
-                "TableSegmentationRefinementService requires networkx." "Please install separately."
+                "TableSegmentationRefinementService requires networkx. Please install separately."
             )
         self.table_name = table_names
         self.cell_names = cell_names

--- a/deepdoctection/pipe/text.py
+++ b/deepdoctection/pipe/text.py
@@ -132,13 +132,7 @@ class TextExtractionService(PipelineComponent):
                     if width is not None and height is not None:
                         box = detect_result.box
                         if box:
-                            if box[0] >= width:
-                                continue
-                            if box[1] >= height:
-                                continue
-                            if box[2] >= width:
-                                continue
-                            if box[3] >= height:
+                            if box[0] >= width or box[1] >= height or box[2] >= width or box[3] >= height:
                                 continue
 
                     if isinstance(self.predictor, TextRecognizer):

--- a/deepdoctection/pipe/text.py
+++ b/deepdoctection/pipe/text.py
@@ -131,14 +131,15 @@ class TextExtractionService(PipelineComponent):
                 for detect_result in detect_result_list:
                     if width is not None and height is not None:
                         box = detect_result.box
-                        if box[0] >= width:
-                            continue
-                        if box[1] >= height:
-                            continue
-                        if box[2] >= width:
-                            continue
-                        if box[3] >= height:
-                            continue
+                        if box:
+                            if box[0] >= width:
+                                continue
+                            if box[1] >= height:
+                                continue
+                            if box[2] >= width:
+                                continue
+                            if box[3] >= height:
+                                continue
 
                     if isinstance(self.predictor, TextRecognizer):
                         detect_ann_id = detect_result.uuid

--- a/deepdoctection/pipe/text.py
+++ b/deepdoctection/pipe/text.py
@@ -129,6 +129,17 @@ class TextExtractionService(PipelineComponent):
                     width, height = self.predictor.get_width_height(predictor_input)  # type: ignore
 
                 for detect_result in detect_result_list:
+                    if width is not None and height is not None:
+                        box = detect_result.box
+                        if box[0] >= width:
+                            continue
+                        if box[1] >= height:
+                            continue
+                        if box[2] >= width:
+                            continue
+                        if box[3] >= height:
+                            continue
+
                     if isinstance(self.predictor, TextRecognizer):
                         detect_ann_id = detect_result.uuid
                     else:

--- a/deepdoctection/pipe/transform.py
+++ b/deepdoctection/pipe/transform.py
@@ -77,6 +77,9 @@ class SimpleTransformService(PipelineComponent):
                         score=ann.score,
                         class_id=ann.category_id,
                         uuid=ann.annotation_id,
+                        angle=detection_result.angle,
+                        image_width=dp.width, # we need the original width, not the transformed width
+                        image_height=dp.height, # same with height
                     )
                 )
             output_detect_results = self.transform_predictor.transform_coords(detect_results)

--- a/deepdoctection/pipe/transform.py
+++ b/deepdoctection/pipe/transform.py
@@ -78,8 +78,8 @@ class SimpleTransformService(PipelineComponent):
                         class_id=ann.category_id,
                         uuid=ann.annotation_id,
                         angle=detection_result.angle,
-                        image_width=dp.width, # we need the original width, not the transformed width
-                        image_height=dp.height, # same with height
+                        image_width=dp.width,  # we need the original width, not the transformed width
+                        image_height=dp.height,  # same with height
                     )
                 )
             output_detect_results = self.transform_predictor.transform_coords(detect_results)

--- a/deepdoctection/utils/file_utils.py
+++ b/deepdoctection/utils/file_utils.py
@@ -8,6 +8,7 @@
 Utilities for maintaining dependencies and dealing with external library packages. Parts of this file is adapted from
 <https://github.com/huggingface/transformers/blob/master/src/transformers/file_utils.py>
 """
+import importlib.metadata
 import importlib.util
 import multiprocessing as mp
 import string
@@ -17,7 +18,6 @@ from shutil import which
 from types import ModuleType
 from typing import Any, Union, no_type_check
 
-import importlib_metadata
 import numpy as np
 from packaging import version
 
@@ -72,9 +72,9 @@ def get_tf_version() -> str:
 
         for pkg in candidates:
             try:
-                tf_version = importlib_metadata.version(pkg)
+                tf_version = importlib.metadata.version(pkg)
                 break
-            except importlib_metadata.PackageNotFoundError:
+            except importlib.metadata.PackageNotFoundError:
                 pass
     return tf_version
 
@@ -175,6 +175,19 @@ def get_pytorch_requirement() -> Requirement:
     return "torch", pytorch_available(), _PYTORCH_ERR_MSG
 
 
+_PYZMQ_AVAILABLE = importlib.util.find_spec("zmq") is not None
+
+
+def pyzmq_available() -> bool:
+    """
+    Returns whether pyzmq is installed.
+
+    Returns:
+        bool: True if pyzmq is installed, False otherwise.
+    """
+    return bool(_PYZMQ_AVAILABLE)
+
+
 # lxml
 _LXML_AVAILABLE = importlib.util.find_spec("lxml") is not None
 _LXML_ERR_MSG = f"lxml must be installed. {_GENERIC_ERR_MSG}"
@@ -232,7 +245,7 @@ _DISTANCE_ERR_MSG = f"distance must be installed. {_GENERIC_ERR_MSG}"
 
 def distance_available() -> bool:
     """
-    Returns whether `distance` is available.
+    Returns True if `distance` is available.
 
     Returns:
         bool: `True` if `distance` is available, False otherwise.
@@ -250,6 +263,22 @@ def get_distance_requirement() -> Requirement:
     return "distance", distance_available(), _DISTANCE_ERR_MSG
 
 
+# networkx
+_NETWORKX_AVAILABLE = importlib.util.find_spec("networkx") is not None
+
+
+def networkx_available() -> bool:
+    """
+    Checks if networkx is installed.
+
+    Returns:
+        bool: True if networkx is installed, False otherwise.
+    :return:
+    """
+    return bool(_NETWORKX_AVAILABLE)
+
+
+# numpy
 _NUMPY_V1_ERR_MSG = "numpy v1 must be installed."
 
 

--- a/deepdoctection/utils/logger.py
+++ b/deepdoctection/utils/logger.py
@@ -144,7 +144,8 @@ class FileFormatter(logging.Formatter):
 
 _LOG_DIR = None
 
-def _coerce_log_level(val: Any) -> Union[int,str]:
+
+def _coerce_log_level(val: Any) -> Union[int, str]:
     """Normalize environment log level values.
 
     Accepts integer values (e.g., ``20``), numeric strings (``"20"``),
@@ -169,7 +170,7 @@ def _coerce_log_level(val: Any) -> Union[int,str]:
     name = s.upper()
     if name == "WARN":
         name = "WARNING"
-    if name in logging._nameToLevel:  #pylint: disable=W0212
+    if name in logging._nameToLevel:  # pylint: disable=W0212
         return name
     lvl = logging.getLevelName(name)
     return lvl if isinstance(lvl, int) else "INFO"

--- a/deepdoctection/utils/logger.py
+++ b/deepdoctection/utils/logger.py
@@ -169,7 +169,7 @@ def _coerce_log_level(val: Any) -> Union[int,str]:
     name = s.upper()
     if name == "WARN":
         name = "WARNING"
-    if name in logging._nameToLevel:  # noqa: SLF001
+    if name in logging._nameToLevel:  #pylint: disable=W0212
         return name
     lvl = logging.getLevelName(name)
     return lvl if isinstance(lvl, int) else "INFO"

--- a/deepdoctection/utils/transform.py
+++ b/deepdoctection/utils/transform.py
@@ -442,17 +442,18 @@ class RotationTransform(BaseTransform):
             raise ValueError("Initialize image_width and image_height first")
 
         if self.angle == 90:
-            coords[:, [0, 1, 2, 3]] = coords[:, [1, 0, 3, 2]]
+            self.image_width = self.image_height
+            coords[:, [0, 1, 2, 3]] = coords[:, [1, 2, 3, 0]]
             coords[:, [1, 3]] = self.image_width - coords[:, [1, 3]]
-            coords[:, [0, 1, 2, 3]] = coords[:, [0, 3, 2, 1]]
         elif self.angle == 180:
-            coords[:, [0, 2]] = self.image_width - coords[:, [0, 2]]
-            coords[:, [1, 3]] = self.image_height - coords[:, [1, 3]]
-            coords[:, [0, 1, 2, 3]] = coords[:, [2, 3, 0, 1]]
+            coords[:, [0, 2]] = self.image_width - coords[:, [2, 0]]
+            coords[:, [1, 3]] = self.image_height - coords[:, [3, 1]]
         elif self.angle == 270:
-            coords[:, [0, 1, 2, 3]] = coords[:, [1, 0, 3, 2]]
+            self.image_height = self.image_width
+            coords[:, [0, 1, 2, 3]] = coords[:, [3, 0, 1, 2]]
             coords[:, [0, 2]] = self.image_height - coords[:, [0, 2]]
-            coords[:, [0, 1, 2, 3]] = coords[:, [2, 1, 0, 3]]
+
+
 
         return coords
 
@@ -473,17 +474,16 @@ class RotationTransform(BaseTransform):
             raise ValueError("Initialize image_width and image_height first")
 
         if self.angle == 90:
-            coords[:, [0, 1, 2, 3]] = coords[:, [1, 0, 3, 2]]
-            coords[:, [0, 2]] = self.image_width - coords[:, [0, 2]]
-            coords[:, [0, 1, 2, 3]] = coords[:, [2, 1, 0, 3]]
+            self.image_height = self.image_width
+            coords[:, [0, 1, 2, 3]] = coords[:, [3, 0, 1, 2]]
+            coords[:, [0, 2]] = self.image_height - coords[:, [0, 2]]
         elif self.angle == 180:
-            coords[:, [0, 2]] = self.image_width - coords[:, [0, 2]]
-            coords[:, [1, 3]] = self.image_height - coords[:, [1, 3]]
-            coords[:, [0, 1, 2, 3]] = coords[:, [2, 3, 0, 1]]
+            coords[:, [0, 2]] = self.image_width - coords[:, [2, 0]]
+            coords[:, [1, 3]] = self.image_height - coords[:, [3, 1]]
         elif self.angle == 270:
-            coords[:, [0, 1, 2, 3]] = coords[:, [1, 0, 3, 2]]
-            coords[:, [1, 3]] = self.image_height - coords[:, [1, 3]]
-            coords[:, [0, 1, 2, 3]] = coords[:, [0, 3, 2, 1]]
+            self.image_width = self.image_height
+            coords[:, [0, 1, 2, 3]] = coords[:, [1, 2, 3, 0]]
+            coords[:, [1, 3]] = self.image_width - coords[:, [1, 3]]
         return coords
 
     def clone(self) -> RotationTransform:

--- a/deepdoctection/utils/transform.py
+++ b/deepdoctection/utils/transform.py
@@ -408,8 +408,8 @@ class RotationTransform(BaseTransform):
             angle: Angle to rotate the image. Must be one of 90, 180, 270, or 360 degrees.
         """
         self.angle = angle
-        self.image_width: Optional[int] = None
-        self.image_height: Optional[int] = None
+        self.image_width: Optional[Union[int, float]] = None
+        self.image_height: Optional[Union[int, float]] = None
 
     def apply_image(self, img: PixelValues) -> PixelValues:
         """

--- a/deepdoctection/utils/transform.py
+++ b/deepdoctection/utils/transform.py
@@ -411,6 +411,33 @@ class RotationTransform(BaseTransform):
         self.image_width: Optional[Union[int, float]] = None
         self.image_height: Optional[Union[int, float]] = None
 
+    def set_angle(self, angle: Literal[90, 180, 270, 360]) -> None:
+        """
+        Set angle
+
+        Args:
+            angle: One of 90, 180, 270, or 360 degrees.
+        """
+        self.angle = angle
+
+    def set_image_width(self, image_width: Union[int, float]) -> None:
+        """
+        Set image width
+
+        Args:
+            image_width: Either a positive integer or 1.
+        """
+        self.image_width = image_width
+
+    def set_image_height(self, image_height: Union[int, float]) -> None:
+        """
+        Set image height
+
+        Args:
+            image_height: Either a positive integer or 1.
+        """
+        self.image_height = image_height
+
     def apply_image(self, img: PixelValues) -> PixelValues:
         """
         Apply rotation to image.
@@ -452,8 +479,6 @@ class RotationTransform(BaseTransform):
             self.image_height = self.image_width
             coords[:, [0, 1, 2, 3]] = coords[:, [3, 0, 1, 2]]
             coords[:, [0, 2]] = self.image_height - coords[:, [0, 2]]
-
-
 
         return coords
 

--- a/deepdoctection/utils/viz.py
+++ b/deepdoctection/utils/viz.py
@@ -423,7 +423,7 @@ class VizPackageHandler:
 
     @staticmethod
     def _cv2_read_image(path: PathLikeOrStr) -> PixelValues:
-        return cv2.imread(os.fspath(path), cv2.IMREAD_COLOR).astype(np.uint8) # type: ignore
+        return cv2.imread(os.fspath(path), cv2.IMREAD_COLOR).astype(np.uint8)  # type: ignore
 
     @staticmethod
     def _pillow_read_image(path: PathLikeOrStr) -> PixelValues:
@@ -517,7 +517,7 @@ class VizPackageHandler:
     @staticmethod
     def _cv2_convert_b64_to_np(image: B64Str) -> PixelValues:
         np_array = np.fromstring(base64.b64decode(image), np.uint8)  # type: ignore
-        np_array = cv2.imdecode(np_array, cv2.IMREAD_COLOR).astype(np.float32) # type: ignore
+        np_array = cv2.imdecode(np_array, cv2.IMREAD_COLOR).astype(np.float32)  # type: ignore
         return np_array.astype(uint8)
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,12 @@ _DEPS = [
     "catalogue==2.0.10",
     "distance==0.1.3",
     "huggingface_hub>=0.26.0",
-    "importlib-metadata>=5.0.0",
     "jsonlines==3.1.0",
     "lazy-imports==0.3.1",
     "lxml>=4.9.1",
     "mock==4.0.3",
     "networkx>=2.7.1",
-    "numpy>2.0", # When using fasttext-wheel, downgrading to numpy<1.x is required
+    "numpy>2.0",  # When using fasttext-wheel, downgrading to numpy<1.x is required
     "opencv-python==4.8.0.76",  # this is not required anymore, but we keep its version as a reference
     "packaging>=20.0",
     "Pillow>=10.0.0",
@@ -90,7 +89,8 @@ _DEPS = [
     "tensorflow-addons>=0.17.1",
     "tf2onnx>=1.9.2",
     "python-doctr==0.10.0",
-    #"fasttext-wheel",
+    # fasttext-wheel is not compatible with numpy v2. Downgrading to numpy<1.x is required
+    # "fasttext-wheel==0.9.2",
     # dev dependencies
     "python-dotenv==1.0.0",
     "click",  # version will not break black
@@ -124,18 +124,15 @@ def deps_list(*pkgs: str):
 dist_deps = deps_list(
     "catalogue",
     "huggingface_hub",
-    "importlib-metadata",
     "jsonlines",
     "lazy-imports",
     "mock",
-    "networkx",
     "numpy",
     "packaging",
     "Pillow",
     "pypdf",
     "pypdfium2",
     "pyyaml",
-    "pyzmq",
     "scipy",
     "termcolor",
     "tabulate",
@@ -147,11 +144,13 @@ dist_deps = deps_list(
 additional_deps = deps_list(
     "boto3",
     "pdfplumber",
-    #"fasttext-wheel",
+    # "fasttext-wheel",
+    "pyzmq",
     "jdeskew",
     "apted",
     "distance",
     "lxml",
+    "networkx",
 )
 
 tf_deps = deps_list("tensorpack", "protobuf", "tensorflow-addons", "tf2onnx", "python-doctr", "pycocotools")

--- a/tests/dataflow/test_parallel_map.py
+++ b/tests/dataflow/test_parallel_map.py
@@ -34,7 +34,7 @@ def map_to_one(dp):
     return np.ones(dp[0].shape)
 
 
-@mark.basic
+@mark.additional
 def test_multithread_map_data_non_strict() -> None:
     """Test MultiThreadMapData non strict"""
 
@@ -50,7 +50,7 @@ def test_multithread_map_data_non_strict() -> None:
     assert len(output) == 20
 
 
-@mark.basic
+@mark.additional
 def test_multithread_map_data_strict() -> None:
     """Test MultiThreadMapData strict"""
 

--- a/tests/extern/test_hflayoutlm.py
+++ b/tests/extern/test_hflayoutlm.py
@@ -126,8 +126,10 @@ class TestHFLayoutLmTokenClassifier:
 
     @staticmethod
     @mark.pt_deps
-    @patch("deepdoctection.extern.hflayoutlm.predict_token_classes_from_layoutlm",
-           MagicMock(side_effect=get_token_class_results))
+    @patch(
+        "deepdoctection.extern.hflayoutlm.predict_token_classes_from_layoutlm",
+        MagicMock(side_effect=get_token_class_results),
+    )
     def test_hf_layout_lm_predicts_token(
         layoutlm_input_for_predictor: JsonDict,
         token_class_names: List[str],
@@ -217,8 +219,10 @@ class TestHFLayoutLmv2TokenClassifier:
 
     @staticmethod
     @mark.pt_deps
-    @patch("deepdoctection.extern.hflayoutlm.predict_token_classes_from_layoutlm",
-           MagicMock(side_effect=get_token_class_results))
+    @patch(
+        "deepdoctection.extern.hflayoutlm.predict_token_classes_from_layoutlm",
+        MagicMock(side_effect=get_token_class_results),
+    )
     def test_hf_layout_lm_predicts_token(
         layoutlm_v2_input: JsonDict,
         token_class_names: List[str],
@@ -310,8 +314,10 @@ class TestHFLayoutLmv3TokenClassifier:
 
     @staticmethod
     @mark.pt_deps
-    @patch("deepdoctection.extern.hflayoutlm.predict_token_classes_from_layoutlm",
-           MagicMock(side_effect=get_token_class_results))
+    @patch(
+        "deepdoctection.extern.hflayoutlm.predict_token_classes_from_layoutlm",
+        MagicMock(side_effect=get_token_class_results),
+    )
     def test_hf_layout_lm_predicts_token(
         layoutlm_v2_input: JsonDict,
         token_class_names: List[str],
@@ -361,7 +367,7 @@ class TestHFLayoutLmSequenceClassifier:
     @mark.pt_deps
     @patch(
         "deepdoctection.extern.hflayoutlm.predict_sequence_classes_from_layoutlm",
-        MagicMock(side_effect=get_sequence_class_result)
+        MagicMock(side_effect=get_sequence_class_result),
     )
     def test_hf_layout_lm_predicts_sequence_class(
         layoutlm_input_for_predictor: JsonDict,
@@ -407,7 +413,7 @@ class TestHFLayoutLmv2SequenceClassifier:
     @mark.pt_deps
     @patch(
         "deepdoctection.extern.hflayoutlm.predict_sequence_classes_from_layoutlm",
-        MagicMock(side_effect=get_sequence_class_result)
+        MagicMock(side_effect=get_sequence_class_result),
     )
     def test_hf_layout_lm_v2_predicts_sequence_class(
         layoutlm_v2_input: JsonDict,
@@ -454,7 +460,7 @@ class TestHFLayoutLmv3SequenceClassifier:
     @mark.pt_deps
     @patch(
         "deepdoctection.extern.hflayoutlm.predict_sequence_classes_from_layoutlm",
-        MagicMock(side_effect=get_sequence_class_result)
+        MagicMock(side_effect=get_sequence_class_result),
     )
     def test_hf_layout_lm_v3_predicts_sequence_class(
         layoutlm_v2_input: JsonDict,
@@ -543,8 +549,10 @@ class TestHFLiltTokenClassifier:
 
     @staticmethod
     @mark.pt_deps
-    @patch("deepdoctection.extern.hflayoutlm.predict_token_classes_from_layoutlm",
-           MagicMock(side_effect=get_token_class_results))
+    @patch(
+        "deepdoctection.extern.hflayoutlm.predict_token_classes_from_layoutlm",
+        MagicMock(side_effect=get_token_class_results),
+    )
     def test_lilt_predicts_token(
         layoutlm_input_for_predictor: JsonDict,
         token_class_names: List[str],

--- a/tests/extern/test_hflm.py
+++ b/tests/extern/test_hflm.py
@@ -70,8 +70,9 @@ class TestHFLmSequenceClassifier:
 
     @staticmethod
     @mark.pt_deps
-    @patch("deepdoctection.extern.hflm.predict_sequence_classes_from_lm",
-           MagicMock(side_effect=get_sequence_class_result))
+    @patch(
+        "deepdoctection.extern.hflm.predict_sequence_classes_from_lm", MagicMock(side_effect=get_sequence_class_result)
+    )
     def test_hf_layout_lm_predicts_sequence_class(
         layoutlm_input_for_predictor: JsonDict,
     ) -> None:

--- a/tests/pipe/test_refine.py
+++ b/tests/pipe/test_refine.py
@@ -36,7 +36,7 @@ from deepdoctection.pipe.refine import (
 from deepdoctection.utils.settings import CellType, LayoutType, TableType
 
 
-@mark.basic
+@mark.additional
 @mark.parametrize(
     "tiles_to_cells,expected_rectangle_cells_list",
     [
@@ -104,7 +104,7 @@ def test_rectangle_cell_tiling(
         assert el in expected_rectangle_cells_list
 
 
-@mark.basic
+@mark.additional
 @mark.parametrize(
     "table_list,cells_ann_list,number_of_rows,number_of_cols,expected_html_list",
     [
@@ -274,7 +274,7 @@ class TestTableSegmentationRefinementService:
             ],
         )
 
-    @mark.basic
+    @mark.additional
     def test_integration_pipeline_component(self, dp_image_fully_segmented_fully_tiled: Image) -> None:
         """
         Integration test for pipeline component


### PR DESCRIPTION
This PR merges v.0.46 into master and includes the following changes:

- Simplifying the dependencies of the default installation: pyzmq (for multithreading and multiprocessing) and networkx (only used in `TableSegmentationService` which isn't the default setting for table recognition anymore) are moved to the `additional_deps`. 
- Allowing to process `TextExtractionService` with `PdfPlumberTextDetector` and provided that there is no text layer to then run an OCR service in a single pipeline. The default analyzer now works seamlessly and this also resolves #379.
- Fixing #349: The only reason that the root logger cannot be configured is that somewhere, when starting a notebook, there is an env `LOG_LEVEL` that returns `info` and then let the configuration of the logger crashes. We now convert everything that I passed to the `_CONFIG_DICT["root"]["level"] to upper cases.
- Fixing #426. As pointed out, `TesseractRotationTransformer` did not have `transform_coords` implemented. We also fixed some transformation issues regarding the rotation of bounding boxes (by multiples of 90 degrees) and also completed the implementation of `DocTrRotationTransformer`. Moreover, it is now possible to select any of the rotation detector engines in a `deepdoctection` pipeline. 
- Adding #424: Now boxes of the same categories have the same color even for different pages. For this, we added a deterministic feature to `random_color`.   